### PR TITLE
Unbreak multi scenario

### DIFF
--- a/apps/actors/main.tsx
+++ b/apps/actors/main.tsx
@@ -8,19 +8,22 @@ import { Tabs } from "../../uiCommon/generic/tabs";
 import { initialState, reducer, ScenarioAction, ScenState } from "./reducers";
 import { SCENARIOS } from "./scenarios";
 import { sendUserInputAsync, spawnAsync } from "./step";
+import useHashParam from "use-hash-param";
 
 function Main() {
   const [state, dispatch] = useReducer(reducer, initialState(SCENARIOS));
+  const [selectedScenarioID, setSelectedScenarioID] = useHashParam(
+    "scenario",
+    SCENARIOS[0].id
+  );
 
   return (
     <>
       <h1>Communicating Processes Viz</h1>
 
       <Tabs
-        setTabID={(scenarioID) =>
-          dispatch({ type: "SelectScenario", scenarioID })
-        }
-        curTabID={state.selectedScenarioID}
+        setTabID={setSelectedScenarioID}
+        curTabID={selectedScenarioID}
         tabs={state.scenStates.map((scenState) => ({
           name: scenState.scenario.name,
           id: scenState.scenario.id,

--- a/apps/actors/main.tsx
+++ b/apps/actors/main.tsx
@@ -159,20 +159,16 @@ function useScenarios<St extends Json, Msg extends Json>(
       `user${id}`,
       scenario.initialUserState
     );
-    const trace3 =
-      nm1.length > 0 ? stepAll(trace2, scenario.update, nm1[0]) : trace2;
-    setTrace(trace3);
-    const { newTrace: trace4, newMessages: nm2 } = Step.spawn(
-      trace3,
-      scenario.update,
-      `client${id}`,
-      scenario.initialClientState
-    );
-    const trace5 =
-      nm2.length > 0 ? stepAll(trace4, scenario.update, nm2[0]) : trace4;
-    setTrace(trace5);
+    stepAllAsync(trace2, scenario.update, nm1, setTrace).then((trace3) => {
+      const { newTrace: trace4, newMessages: nm2 } = Step.spawn(
+        trace3,
+        scenario.update,
+        `client${id}`,
+        scenario.initialClientState
+      );
+      stepAllAsync(trace4, scenario.update, nm2, setTrace);
+    });
   };
-
   const exitClient = (id: number) => {
     updateScenState((old) => ({
       ...old,

--- a/apps/actors/main.tsx
+++ b/apps/actors/main.tsx
@@ -30,7 +30,7 @@ function Main() {
                 dispatch={(action) =>
                   dispatch({
                     type: "UpdateScenario",
-                    scenarioID: scenState.scenario.name,
+                    scenarioID: scenState.scenario.id,
                     action,
                   })
                 }

--- a/apps/actors/main.tsx
+++ b/apps/actors/main.tsx
@@ -7,7 +7,7 @@ import { Json } from "../../util/json";
 import { Tabs } from "../../uiCommon/generic/tabs";
 import { initialState, reducer, ScenarioAction, ScenState } from "./reducers";
 import { SCENARIOS } from "./scenarios";
-import { sendUserInputAsync } from "./step";
+import { sendUserInputAsync, spawnAsync } from "./step";
 
 function Main() {
   const [state, dispatch] = useReducer(reducer, initialState(SCENARIOS));
@@ -101,7 +101,17 @@ function MultiClient<St extends Json, Msg extends Json>(props: {
           );
         })}
       </ul>
-      <button onClick={() => props.dispatch({ type: "SpawnClient" })}>
+      <button
+        onClick={() => {
+          props.dispatch({ type: "BumpNextClientID" });
+          spawnAsync(
+            props.scenState.trace,
+            props.scenState.scenario,
+            props.scenState.nextClientID,
+            (newTrace) => props.dispatch({ type: "UpdateTrace", newTrace })
+          );
+        }}
+      >
         Add Client
       </button>
     </>

--- a/apps/actors/main.tsx
+++ b/apps/actors/main.tsx
@@ -7,6 +7,7 @@ import { Json } from "../../util/json";
 import { Tabs } from "../../uiCommon/generic/tabs";
 import { initialState, reducer, ScenarioAction, ScenState } from "./reducers";
 import { SCENARIOS } from "./scenarios";
+import { sendUserInputAsync } from "./step";
 
 function Main() {
   const [state, dispatch] = useReducer(reducer, initialState(SCENARIOS));
@@ -63,6 +64,17 @@ function MultiClient<St extends Json, Msg extends Json>(props: {
   scenState: ScenState<St, Msg>;
   dispatch: (action: ScenarioAction<St, Msg>) => void;
 }) {
+  // TODO: extract into stepAllAsync
+  const sendInput = (clientID: number, input: Msg) => {
+    sendUserInputAsync(
+      props.scenState.trace,
+      props.scenState.scenario.update,
+      clientID,
+      input,
+      (newTrace) => props.dispatch({ type: "UpdateTrace", newTrace })
+    );
+  };
+
   return (
     <>
       <ul>
@@ -82,9 +94,7 @@ function MultiClient<St extends Json, Msg extends Json>(props: {
               {clientState ? (
                 <props.scenState.scenario.ui
                   state={clientState}
-                  sendUserInput={(input) =>
-                    props.dispatch({ type: "SendInput", clientID, input })
-                  }
+                  sendUserInput={(input) => sendInput(clientID, input)}
                 />
               ) : null}
             </li>

--- a/apps/actors/main.tsx
+++ b/apps/actors/main.tsx
@@ -1,46 +1,39 @@
 import * as React from "react";
-import { useState } from "react";
+import { useReducer } from "react";
 import * as ReactDOM from "react-dom";
-import { scenario as simpleCounter } from "./scenarios/simpleCounter";
-import { scenario as todoMVC } from "./scenarios/todoMVC";
-import useHashParam from "use-hash-param";
 import { Explorer } from "../../uiCommon/explorer";
-import { Scenario, Trace } from "./types";
 import ReactJson from "react-json-view";
-import * as Step from "./step";
 import { Json } from "../../util/json";
 import { Tabs } from "../../uiCommon/generic/tabs";
-import { insertUserInput, stepAll, stepAllAsync } from "./step";
-import { updateList } from "../../util/util";
-
-const SCENARIOS: Scenario<any, any>[] = [todoMVC, simpleCounter];
+import { initialState, reducer, ScenarioAction, ScenState } from "./reducers";
+import { SCENARIOS } from "./scenarios";
 
 function Main() {
-  const {
-    trace,
-    sendInput,
-    selectedScenarioID,
-    setSelectedScenarioID,
-    multiClient,
-  } = useScenarios(SCENARIOS);
+  const [state, dispatch] = useReducer(reducer, initialState(SCENARIOS));
 
   return (
     <>
       <h1>Communicating Processes Viz</h1>
 
       <Tabs
-        setTabID={setSelectedScenarioID}
-        curTabID={selectedScenarioID}
-        tabs={SCENARIOS.map((scenario) => ({
-          name: scenario.name,
-          id: scenario.id,
+        setTabID={(scenarioID) =>
+          dispatch({ type: "SelectScenario", scenarioID })
+        }
+        curTabID={state.selectedScenarioID}
+        tabs={state.scenStates.map((scenState) => ({
+          name: scenState.scenario.name,
+          id: scenState.scenario.id,
           render: () => {
             return (
-              <Animated
-                scenario={scenario}
-                multiClient={multiClient}
-                sendInput={sendInput}
-                trace={trace}
+              <Scenario
+                scenState={scenState}
+                dispatch={(action) =>
+                  dispatch({
+                    type: "UpdateScenario",
+                    scenarioID: scenState.scenario.name,
+                    action,
+                  })
+                }
               />
             );
           },
@@ -50,183 +43,57 @@ function Main() {
   );
 }
 
-function Animated<ActorState extends Json, Msg extends Json>(props: {
-  scenario: Scenario<ActorState, Msg>;
-  trace: Trace<ActorState, Msg>;
-  sendInput: (fromUserID: number, input: Msg) => void;
-  multiClient: MultiClientProps;
+function Scenario<St extends Json, Msg extends Json>(props: {
+  scenState: ScenState<St, Msg>;
+  dispatch: (action: ScenarioAction<St, Msg>) => void;
 }) {
   return (
     <>
-      <MultiClient
-        trace={props.trace}
-        sendInput={props.sendInput}
-        scenario={props.scenario}
-        multiClient={props.multiClient}
-      />
+      <MultiClient scenState={props.scenState} dispatch={props.dispatch} />
 
-      <Explorer interp={props.trace.interp} showViz={true} />
+      <Explorer interp={props.scenState.trace.interp} showViz={true} />
 
       <h2>State</h2>
-      <ReactJson src={props.trace.latestStates} />
+      <ReactJson src={props.scenState.trace.latestStates} />
     </>
   );
 }
 
-type ScenState<ActorState, Msg> = {
-  scenario: Scenario<ActorState, Msg>;
-  trace: Trace<ActorState, Msg>;
-  clientIDs: number[];
-  nextClientID: number;
-};
-
-// TODO: does all of this have to be bundled into one hook?
-function useScenarios<St extends Json, Msg extends Json>(
-  scenarios: Scenario<St, Msg>[]
-): {
-  trace: Trace<St, Msg>;
-  sendInput: (fromUserID: number, input: Msg) => void;
-  selectedScenarioID: string;
-  setSelectedScenarioID: (id: string) => void;
-  multiClient: MultiClientProps;
-} {
-  const [scenStates, setScenStates] = useState<ScenState<any, any>[]>(
-    scenarios.map((scenario) => ({
-      scenario,
-      trace: scenario.initialState,
-      clientIDs: [],
-      nextClientID: 0,
-    }))
-  );
-  const [selectedScenarioID, setSelectedScenarioID] = useHashParam(
-    "scenario",
-    scenarios[0].id
-  );
-
-  const scenState = scenStates.find(
-    (scenAndState) => scenAndState.scenario.id === selectedScenarioID
-  );
-  const trace = scenState.trace;
-  const scenario = scenState.scenario;
-  const updateScenState = (
-    fn: (old: ScenState<St, Msg>) => ScenState<St, Msg>
-  ) => {
-    setScenStates(
-      updateList(
-        scenStates,
-        (scenState) => scenState.scenario.id === scenario.id,
-        fn
-      )
-    );
-  };
-  const setTrace = (newTrace) => {
-    updateScenState((old) => ({ ...old, trace: newTrace }));
-  };
-
-  const sendInput = (fromUserID: number, input: Msg) => {
-    const { newTrace, newMessageID } = insertUserInput(
-      trace,
-      scenario.update,
-      fromUserID,
-      input
-    );
-    setTrace(newTrace);
-    stepAllAsync(
-      newTrace,
-      scenario.update,
-      [
-        {
-          from: `user${fromUserID}`,
-          to: `client${fromUserID}`,
-          init: { type: "messageReceived", messageID: newMessageID.toString() },
-        },
-      ],
-      setTrace
-    );
-  };
-
-  const spawnClient = () => {
-    const id = scenState.nextClientID;
-    updateScenState((old) => ({
-      ...old,
-      nextClientID: old.nextClientID + 1,
-      clientIDs: [...old.clientIDs, id],
-    }));
-
-    const { newTrace: trace2, newMessages: nm1 } = Step.spawn(
-      trace,
-      scenario.update,
-      `user${id}`,
-      scenario.initialUserState
-    );
-    stepAllAsync(trace2, scenario.update, nm1, setTrace).then((trace3) => {
-      const { newTrace: trace4, newMessages: nm2 } = Step.spawn(
-        trace3,
-        scenario.update,
-        `client${id}`,
-        scenario.initialClientState
-      );
-      stepAllAsync(trace4, scenario.update, nm2, setTrace);
-    });
-  };
-  const exitClient = (id: number) => {
-    updateScenState((old) => ({
-      ...old,
-      clientIDs: old.clientIDs.filter((curID) => curID !== id),
-    }));
-  };
-
-  return {
-    trace,
-    sendInput,
-    selectedScenarioID,
-    setSelectedScenarioID,
-    multiClient: {
-      spawnClient,
-      exitClient,
-      clientIDs: scenState.clientIDs,
-    },
-  };
-}
-
-type MultiClientProps = {
-  clientIDs: number[];
-  spawnClient: () => void;
-  exitClient: (id: number) => void;
-};
-
 function MultiClient<St extends Json, Msg extends Json>(props: {
-  trace: Trace<St, Msg>;
-  sendInput: (fromUserID: number, msg: Msg) => void;
-  scenario: Scenario<St, Msg>;
-  multiClient: MultiClientProps;
+  scenState: ScenState<St, Msg>;
+  dispatch: (action: ScenarioAction<St, Msg>) => void;
 }) {
   return (
     <>
       <ul>
-        {props.multiClient.clientIDs.map((clientID) => {
-          const clientState = props.trace.latestStates[`client${clientID}`];
+        {props.scenState.clientIDs.map((clientID) => {
+          const clientState =
+            props.scenState.trace.latestStates[`client${clientID}`];
 
           return (
             <li key={clientID}>
               <button
                 onClick={() => {
-                  props.multiClient.exitClient(clientID);
+                  props.dispatch({ type: "ExitClient", clientID });
                 }}
               >
                 x
               </button>
               {clientState ? (
-                <props.scenario.ui
+                <props.scenState.scenario.ui
                   state={clientState}
-                  sendUserInput={(msg) => props.sendInput(clientID, msg)}
+                  sendUserInput={(input) =>
+                    props.dispatch({ type: "SendInput", clientID, input })
+                  }
                 />
               ) : null}
             </li>
           );
         })}
       </ul>
-      <button onClick={props.multiClient.spawnClient}>Add Client</button>
+      <button onClick={() => props.dispatch({ type: "SpawnClient" })}>
+        Add Client
+      </button>
     </>
   );
 }

--- a/apps/actors/main.tsx
+++ b/apps/actors/main.tsx
@@ -64,7 +64,6 @@ function MultiClient<St extends Json, Msg extends Json>(props: {
   scenState: ScenState<St, Msg>;
   dispatch: (action: ScenarioAction<St, Msg>) => void;
 }) {
-  // TODO: extract into stepAllAsync
   const sendInput = (clientID: number, input: Msg) => {
     sendUserInputAsync(
       props.scenState.trace,
@@ -103,7 +102,7 @@ function MultiClient<St extends Json, Msg extends Json>(props: {
       </ul>
       <button
         onClick={() => {
-          props.dispatch({ type: "BumpNextClientID" });
+          props.dispatch({ type: "AllocateClientID" });
           spawnAsync(
             props.scenState.trace,
             props.scenState.scenario,

--- a/apps/actors/reducers.ts
+++ b/apps/actors/reducers.ts
@@ -1,0 +1,130 @@
+import { updateList } from "../../util/util";
+import { Scenario, Trace } from "./types";
+import { Json } from "../../util/json";
+import * as Step from "./step";
+import { insertUserInput, stepAll } from "./step";
+
+type State<St, Msg> = {
+  selectedScenarioID: string;
+  scenStates: ScenState<St, Msg>[];
+};
+
+type Action<St, Msg> =
+  | {
+      type: "UpdateScenario";
+      action: ScenarioAction<St, Msg>;
+      scenarioID: string;
+    }
+  | { type: "SelectScenario"; scenarioID: string };
+
+export function initialState<St, Msg>(
+  scenarios: Scenario<St, Msg>[]
+): State<St, Msg> {
+  return {
+    scenStates: scenarios.map((scenario) => ({
+      scenario,
+      trace: scenario.initialState,
+      clientIDs: [],
+      nextClientID: 0,
+    })),
+    // TODO: how do I connect this to good ol' useHashParam?
+    selectedScenarioID: scenarios[0].id,
+  };
+}
+
+export function reducer<St extends Json, Msg extends Json>(
+  state: State<St, Msg>,
+  action: Action<St, Msg>
+): State<St, Msg> {
+  switch (action.type) {
+    case "SelectScenario":
+      return { ...state, selectedScenarioID: action.scenarioID };
+    case "UpdateScenario":
+      return {
+        ...state,
+        scenStates: updateList(
+          state.scenStates,
+          (scenState) => scenState.scenario.id === action.scenarioID,
+          (old) => scenarioReducer(old, action.action)
+        ),
+      };
+  }
+}
+
+export type ScenState<ActorState, Msg> = {
+  scenario: Scenario<ActorState, Msg>;
+  trace: Trace<ActorState, Msg>;
+  clientIDs: number[];
+  nextClientID: number;
+};
+
+export type ScenarioAction<St, Msg> =
+  | {
+      type: "SendInput";
+      input: Msg;
+      clientID: number;
+    }
+  | { type: "SpawnClient" }
+  | { type: "ExitClient"; clientID: number };
+
+function scenarioReducer<St extends Json, Msg extends Json>(
+  scenState: ScenState<St, Msg>,
+  action: ScenarioAction<St, Msg>
+): ScenState<St, Msg> {
+  switch (action.type) {
+    case "SpawnClient": {
+      const scenario = scenState.scenario;
+      const trace = scenState.trace;
+      const id = scenState.nextClientID;
+      const { newTrace: trace2, newMessages: nm1 } = Step.spawn(
+        trace,
+        scenario.update,
+        `user${id}`,
+        scenario.initialUserState
+      );
+      const trace3 = stepAll(trace2, scenario.update, nm1);
+
+      const { newTrace: trace4, newMessages: nm2 } = Step.spawn(
+        trace3,
+        scenario.update,
+        `client${id}`,
+        scenario.initialClientState
+      );
+      const trace5 = stepAll(trace4, scenario.update, nm2);
+      return {
+        ...scenState,
+        trace: trace5,
+        clientIDs: [...scenState.clientIDs, scenState.nextClientID],
+        nextClientID: scenState.nextClientID + 1,
+      };
+    }
+    case "ExitClient":
+      // TODO: mark it as exited in the trace
+      return {
+        ...scenState,
+        clientIDs: scenState.clientIDs.filter((id) => id !== action.clientID),
+      };
+    case "SendInput": {
+      const trace = scenState.trace;
+      const scenario = scenState.scenario;
+      const { newTrace: trace2, newMessageID } = insertUserInput(
+        trace,
+        scenario.update,
+        action.clientID,
+        action.input
+      );
+      const trace3 = stepAll(trace2, scenario.update, [
+        {
+          from: `user${action.clientID}`,
+          to: `client${action.clientID}`,
+          init: {
+            type: "messageReceived",
+            messageID: newMessageID.toString(),
+          },
+        },
+      ]);
+
+      return { ...scenState, trace: trace3 };
+    }
+  }
+}

--- a/apps/actors/reducers.ts
+++ b/apps/actors/reducers.ts
@@ -53,16 +53,15 @@ export function reducer<St extends Json, Msg extends Json>(
 
 export type ScenState<ActorState, Msg> = {
   scenario: Scenario<ActorState, Msg>;
-  trace: Trace<ActorState, Msg>;
+  trace: Trace<ActorState>;
   clientIDs: number[];
   nextClientID: number;
 };
 
 export type ScenarioAction<St, Msg> =
   | {
-      type: "SendInput";
-      input: Msg;
-      clientID: number;
+      type: "UpdateTrace";
+      newTrace: Trace<St>;
     }
   | { type: "SpawnClient" }
   | { type: "ExitClient"; clientID: number };
@@ -104,27 +103,8 @@ function scenarioReducer<St extends Json, Msg extends Json>(
         ...scenState,
         clientIDs: scenState.clientIDs.filter((id) => id !== action.clientID),
       };
-    case "SendInput": {
-      const trace = scenState.trace;
-      const scenario = scenState.scenario;
-      const { newTrace: trace2, newMessageID } = insertUserInput(
-        trace,
-        scenario.update,
-        action.clientID,
-        action.input
-      );
-      const trace3 = stepAll(trace2, scenario.update, [
-        {
-          from: `user${action.clientID}`,
-          to: `client${action.clientID}`,
-          init: {
-            type: "messageReceived",
-            messageID: newMessageID.toString(),
-          },
-        },
-      ]);
-
-      return { ...scenState, trace: trace3 };
+    case "UpdateTrace": {
+      return { ...scenState, trace: action.newTrace };
     }
   }
 }

--- a/apps/actors/reducers.ts
+++ b/apps/actors/reducers.ts
@@ -63,7 +63,7 @@ export type ScenarioAction<St, Msg> =
       type: "UpdateTrace";
       newTrace: Trace<St>;
     }
-  | { type: "SpawnClient" }
+  | { type: "BumpNextClientID" }
   | { type: "ExitClient"; clientID: number };
 
 function scenarioReducer<St extends Json, Msg extends Json>(
@@ -71,40 +71,15 @@ function scenarioReducer<St extends Json, Msg extends Json>(
   action: ScenarioAction<St, Msg>
 ): ScenState<St, Msg> {
   switch (action.type) {
-    case "SpawnClient": {
-      const scenario = scenState.scenario;
-      const trace = scenState.trace;
-      const id = scenState.nextClientID;
-      const { newTrace: trace2, newMessages: nm1 } = Step.spawn(
-        trace,
-        scenario.update,
-        `user${id}`,
-        scenario.initialUserState
-      );
-      const trace3 = stepAll(trace2, scenario.update, nm1);
-
-      const { newTrace: trace4, newMessages: nm2 } = Step.spawn(
-        trace3,
-        scenario.update,
-        `client${id}`,
-        scenario.initialClientState
-      );
-      const trace5 = stepAll(trace4, scenario.update, nm2);
-      return {
-        ...scenState,
-        trace: trace5,
-        clientIDs: [...scenState.clientIDs, scenState.nextClientID],
-        nextClientID: scenState.nextClientID + 1,
-      };
-    }
     case "ExitClient":
       // TODO: mark it as exited in the trace
       return {
         ...scenState,
         clientIDs: scenState.clientIDs.filter((id) => id !== action.clientID),
       };
-    case "UpdateTrace": {
+    case "UpdateTrace":
       return { ...scenState, trace: action.newTrace };
-    }
+    case "BumpNextClientID":
+      return { ...scenState, nextClientID: scenState.nextClientID + 1 };
   }
 }

--- a/apps/actors/reducers.ts
+++ b/apps/actors/reducers.ts
@@ -1,8 +1,6 @@
 import { updateList } from "../../util/util";
 import { Scenario, Trace } from "./types";
 import { Json } from "../../util/json";
-import * as Step from "./step";
-import { stepAll } from "./step";
 
 type State<St, Msg> = {
   selectedScenarioID: string;
@@ -63,7 +61,7 @@ export type ScenarioAction<St, Msg> =
       type: "UpdateTrace";
       newTrace: Trace<St>;
     }
-  | { type: "BumpNextClientID" }
+  | { type: "AllocateClientID" }
   | { type: "ExitClient"; clientID: number };
 
 function scenarioReducer<St extends Json, Msg extends Json>(
@@ -79,7 +77,11 @@ function scenarioReducer<St extends Json, Msg extends Json>(
       };
     case "UpdateTrace":
       return { ...scenState, trace: action.newTrace };
-    case "BumpNextClientID":
-      return { ...scenState, nextClientID: scenState.nextClientID + 1 };
+    case "AllocateClientID":
+      return {
+        ...scenState,
+        clientIDs: [...scenState.clientIDs, scenState.nextClientID],
+        nextClientID: scenState.nextClientID + 1,
+      };
   }
 }

--- a/apps/actors/reducers.ts
+++ b/apps/actors/reducers.ts
@@ -3,17 +3,15 @@ import { Scenario, Trace } from "./types";
 import { Json } from "../../util/json";
 
 type State<St, Msg> = {
-  selectedScenarioID: string;
   scenStates: ScenState<St, Msg>[];
 };
 
-type Action<St, Msg> =
-  | {
-      type: "UpdateScenario";
-      action: ScenarioAction<St, Msg>;
-      scenarioID: string;
-    }
-  | { type: "SelectScenario"; scenarioID: string };
+// TODO: only one action... is this reducer even necessary?
+type Action<St, Msg> = {
+  type: "UpdateScenario";
+  action: ScenarioAction<St, Msg>;
+  scenarioID: string;
+};
 
 export function initialState<St, Msg>(
   scenarios: Scenario<St, Msg>[]
@@ -25,8 +23,6 @@ export function initialState<St, Msg>(
       clientIDs: [],
       nextClientID: 0,
     })),
-    // TODO: how do I connect this to good ol' useHashParam?
-    selectedScenarioID: scenarios[0].id,
   };
 }
 
@@ -35,8 +31,6 @@ export function reducer<St extends Json, Msg extends Json>(
   action: Action<St, Msg>
 ): State<St, Msg> {
   switch (action.type) {
-    case "SelectScenario":
-      return { ...state, selectedScenarioID: action.scenarioID };
     case "UpdateScenario":
       return {
         ...state,

--- a/apps/actors/reducers.ts
+++ b/apps/actors/reducers.ts
@@ -2,7 +2,7 @@ import { updateList } from "../../util/util";
 import { Scenario, Trace } from "./types";
 import { Json } from "../../util/json";
 import * as Step from "./step";
-import { insertUserInput, stepAll } from "./step";
+import { stepAll } from "./step";
 
 type State<St, Msg> = {
   selectedScenarioID: string;

--- a/apps/actors/scenarios/index.ts
+++ b/apps/actors/scenarios/index.ts
@@ -1,0 +1,5 @@
+import { Scenario } from "../types";
+import { scenario as todoMVC } from "./todoMVC";
+import { scenario as simpleCounter } from "./simpleCounter";
+
+export const SCENARIOS: Scenario<any, any>[] = [todoMVC, simpleCounter];

--- a/apps/actors/scenarios/simpleCounter.tsx
+++ b/apps/actors/scenarios/simpleCounter.tsx
@@ -41,7 +41,7 @@ type ServerResp = "ack";
 
 const initialClientState = { type: "ClientState", value: 0, status: "steady" };
 
-export function getInitialState(): Trace<State, Msg> {
+export function getInitialState(): Trace<State> {
   return spawnInitialActors(update, {
     server: { type: "ServerState", value: 0 },
   });

--- a/apps/actors/scenarios/simpleCounter.tsx
+++ b/apps/actors/scenarios/simpleCounter.tsx
@@ -49,6 +49,7 @@ export function getInitialState(): Trace<State> {
 
 // behaviors
 
+// TODO: push out updates to clients
 export function server(
   state: ServerState,
   init: LoadedTickInitiator<ServerState, MsgToServer>
@@ -140,7 +141,14 @@ export function ClientServerUI(props: {
 }) {
   return (
     <>
-      <h2>Client</h2>
+      <h2>Counter</h2>
+      <span
+        style={{
+          color: props.state.status === "saving" ? "lightgrey" : "",
+        }}
+      >
+        Value: {props.state.value}{" "}
+      </span>
       <button onClick={() => props.sendUserInput("decrement")}>-</button>
       <button onClick={() => props.sendUserInput("increment")}>+</button>
     </>

--- a/apps/actors/scenarios/todoMVC.tsx
+++ b/apps/actors/scenarios/todoMVC.tsx
@@ -83,7 +83,7 @@ type PutTodoResp = { type: "putTodoResp"; todo: Todo };
 
 // initial state
 
-export function getInitialState(): Trace<State, Msg> {
+export function getInitialState(): Trace<State> {
   return spawnInitialActors(update, {
     server: {
       type: "serverState",

--- a/apps/actors/step.ts
+++ b/apps/actors/step.ts
@@ -6,6 +6,7 @@ import {
   AddressedTickInitiator,
   initialTrace,
   LoadedTickInitiator,
+  Scenario,
   TickInitiator,
   Trace,
   UpdateFn,
@@ -159,7 +160,29 @@ export function spawnInitialActors<ActorState extends Json, Msg extends Json>(
   );
 }
 
-export function spawn<ActorState extends Json, Msg extends Json>(
+export async function spawnAsync<ActorState extends Json, Msg extends Json>(
+  trace: Trace<ActorState>,
+  scenario: Scenario<ActorState, Msg>,
+  id: number,
+  updateTrace: (newTrace: Trace<ActorState>) => void
+) {
+  const { newTrace: trace2, newMessages: nm1 } = spawn(
+    trace,
+    scenario.update,
+    `user${id}`,
+    scenario.initialUserState
+  );
+  const trace3 = await stepAllAsync(trace2, scenario.update, updateTrace, nm1);
+  const { newTrace: trace4, newMessages: nm2 } = spawn(
+    trace3,
+    scenario.update,
+    `client${id}`,
+    scenario.initialClientState
+  );
+  await stepAllAsync(trace4, scenario.update, updateTrace, nm2);
+}
+
+function spawn<ActorState extends Json, Msg extends Json>(
   trace: Trace<ActorState>,
   update: UpdateFn<ActorState, Msg>,
   id: string,

--- a/apps/actors/step.ts
+++ b/apps/actors/step.ts
@@ -39,7 +39,9 @@ export async function stepAllAsync<ActorState extends Json, Msg extends Json>(
   setTrace: (trace: Trace<ActorState>) => void,
   queue: AddressedTickInitiator<ActorState>[]
 ): Promise<Trace<ActorState>> {
+  // TODO: get away with one if statement and one setTrace?
   if (queue.length === 0) {
+    setTrace(trace);
     return trace;
   }
 

--- a/apps/actors/types.ts
+++ b/apps/actors/types.ts
@@ -2,21 +2,18 @@ import { AbstractInterpreter } from "../../core/abstractInterpreter";
 import { makeMemoryLoader } from "../../core/loaders";
 // @ts-ignore
 import patterns from "./patterns.dl";
-import { SimpleInterpreter } from "../../core/simple/interpreter";
 import { IncrementalInterpreter } from "../../core/incremental/interpreter";
-import { toGraphviz } from "../../core/incremental/graphviz";
-import { prettyPrintGraph } from "../../util/graphviz";
 import React from "react";
 
 // === overall model ===
 
-export type Trace<ActorState, Msg> = {
+export type Trace<ActorState> = {
   latestStates: { [actorID: string]: ActorState }; // TODO: can we get this in the DB somehow?
   nextID: number;
   interp: AbstractInterpreter;
 };
 
-export function initialTrace<ActorState, Msg>(): Trace<ActorState, Msg> {
+export function initialTrace<ActorState>(): Trace<ActorState> {
   const interp = new IncrementalInterpreter(
     ".",
     makeMemoryLoader({
@@ -103,7 +100,7 @@ export type Scenario<ActorState, Msg> = {
   }) => React.ReactElement;
   update: UpdateFn<ActorState, Msg>;
   // TODO: something about all these initial states
-  initialState: Trace<ActorState, Msg>;
+  initialState: Trace<ActorState>;
   initialClientState: ActorState;
   initialUserState: ActorState;
 };


### PR DESCRIPTION
#30 broke the preservation of state while switching between scenarios. This fixes it.

Got rid of custom `useScenario` hook; rewrote with `useReducer`. Breaking the logic out like this seems nice.