### PR TITLE
syntax highlighting w/ datalog for runtime-defined grammars

### DIFF
--- a/apps/languageWorkbench/codeEditor.tsx
+++ b/apps/languageWorkbench/codeEditor.tsx
@@ -36,21 +36,6 @@ export function CodeEditor(props: {
           props.onCursorPosChange(evt.currentTarget.selectionStart)
         }
       />
-      {/* TODO: make this editable at runtime */}
-      <style>{`
-          .segment-ident {
-              color: purple;
-          }
-          .segment-var {
-              color: orange;
-          }
-          .segment-int {
-              color: blue;
-          }
-          .segment-string {
-              color: green;
-          }
-      `}</style>
     </>
   );
 }

--- a/apps/languageWorkbench/codeEditor.tsx
+++ b/apps/languageWorkbench/codeEditor.tsx
@@ -35,6 +35,9 @@ export function CodeEditor(props: {
           .segment-ident {
               color: purple;
           }
+          .segment-var {
+              color: orange;
+          }
       `}</style>
     </>
   );

--- a/apps/languageWorkbench/codeEditor.tsx
+++ b/apps/languageWorkbench/codeEditor.tsx
@@ -36,6 +36,7 @@ export function CodeEditor(props: {
           props.onCursorPosChange(evt.currentTarget.selectionStart)
         }
       />
+      {/* TODO: make this editable at runtime */}
       <style>{`
           .segment-ident {
               color: purple;

--- a/apps/languageWorkbench/codeEditor.tsx
+++ b/apps/languageWorkbench/codeEditor.tsx
@@ -9,6 +9,7 @@ export function CodeEditor(props: {
   cursorPos: number;
   onCursorPosChange: (n: number) => void;
   interp: AbstractInterpreter;
+  validGrammar: boolean;
 }) {
   return (
     <>
@@ -22,7 +23,11 @@ export function CodeEditor(props: {
         padding={5}
         value={props.source}
         onValueChange={(source) => props.onSourceChange(source)}
-        highlight={(_) => highlight(props.interp, props.source, 0, [])}
+        highlight={(_) =>
+          props.validGrammar
+            ? highlight(props.interp, props.source, 0, [])
+            : props.source
+        }
         cursorPos={props.cursorPos}
         onKeyUp={(evt) =>
           props.onCursorPosChange(evt.currentTarget.selectionStart)
@@ -40,6 +45,9 @@ export function CodeEditor(props: {
           }
           .segment-int {
               color: blue;
+          }
+          .segment-string {
+              color: green;
           }
       `}</style>
     </>

--- a/apps/languageWorkbench/codeEditor.tsx
+++ b/apps/languageWorkbench/codeEditor.tsx
@@ -38,6 +38,9 @@ export function CodeEditor(props: {
           .segment-var {
               color: orange;
           }
+          .segment-int {
+              color: blue;
+          }
       `}</style>
     </>
   );

--- a/apps/languageWorkbench/codeEditor.tsx
+++ b/apps/languageWorkbench/codeEditor.tsx
@@ -17,7 +17,7 @@ export function CodeEditor(props: {
         style={{
           fontFamily: "monospace",
           width: 300,
-          height: 150,
+          height: 200,
           border: "1px solid black",
         }}
         padding={5}

--- a/apps/languageWorkbench/codeEditor.tsx
+++ b/apps/languageWorkbench/codeEditor.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { AbstractInterpreter } from "../../core/abstractInterpreter";
+import Editor from "../../uiCommon/ide/editor";
+import { highlight } from "../../uiCommon/ide/highlight";
+
+export function CodeEditor(props: {
+  source: string;
+  onSourceChange: (s: string) => void;
+  cursorPos: number;
+  onCursorPosChange: (n: number) => void;
+  interp: AbstractInterpreter;
+}) {
+  return (
+    <>
+      <Editor
+        style={{
+          fontFamily: "monospace",
+          width: 300,
+          height: 150,
+          border: "1px solid black",
+        }}
+        padding={5}
+        value={props.source}
+        onValueChange={(source) => props.onSourceChange(source)}
+        highlight={(_) => highlight(props.interp, props.source, 0, [])}
+        cursorPos={props.cursorPos}
+        onKeyUp={(evt) =>
+          props.onCursorPosChange(evt.currentTarget.selectionStart)
+        }
+        onClick={(evt) =>
+          props.onCursorPosChange(evt.currentTarget.selectionStart)
+        }
+      />
+      <style>{`
+          .segment-ident {
+              color: purple;
+          }
+      `}</style>
+    </>
+  );
+}

--- a/apps/languageWorkbench/examples/dl/grammar.txt
+++ b/apps/languageWorkbench/examples/dl/grammar.txt
@@ -1,12 +1,12 @@
-main :- repSep(stmt, [".", "\n"]).
-stmt :- rule.
+main :- record.
+stmt :- [rule, "."].
 
 rule :- [record, ws, ":-", "ws", repSep(disjunct, [ws, "|", ws])].
 disjunct :- repSep(record, [ws, "&", ws]).
 
 term :- (record | int | var).
-var :- [[A-Z], repSep([a-z], "")].
-record :- [ident, "{", repSep(keyValue, ","), "}"].
+var :- [[A-Z], repSep([A-Z], "")].
+record :- [ident, "{", repSep(keyValue, [",", ws]), "}"].
 keyValue :- [ident, ":", ws, term].
 int :- [num, repSep(num, "")].
 

--- a/apps/languageWorkbench/examples/dl/grammar.txt
+++ b/apps/languageWorkbench/examples/dl/grammar.txt
@@ -1,0 +1,17 @@
+main :- repSep(stmt, [".", "\n"]).
+stmt :- rule.
+
+rule :- [record, ws, ":-", "ws", repSep(disjunct, [ws, "|", ws])].
+disjunct :- repSep(record, [ws, "&", ws]).
+
+term :- (record | int | var).
+var :- [[A-Z], repSep([a-z], "")].
+record :- [ident, "{", repSep(keyValue, ","), "}"].
+keyValue :- [ident, ":", ws, term].
+int :- [num, repSep(num, "")].
+
+alpha :- ([a-z] | [A-Z] | "_").
+num :- [0-9].
+alphaNum :- (alpha | num).
+ident :- [alpha, repSep((alphaNum | "."), "")].
+ws :- repSep((" "|"\n"), "").

--- a/apps/languageWorkbench/examples/dl/grammar.txt
+++ b/apps/languageWorkbench/examples/dl/grammar.txt
@@ -1,7 +1,8 @@
-main :- record.
+main :- repSep((stmt | comment), ws).
 stmt :- [rule, "."].
+comment :- ["#", repSep(([a-z]|[A-Z]|" "), "")].
 
-rule :- [record, ws, ":-", "ws", repSep(disjunct, [ws, "|", ws])].
+rule :- [record, ws, ":-", ws, repSep(disjunct, [ws, "|", ws])].
 disjunct :- repSep(record, [ws, "&", ws]).
 
 term :- (record | int | var).

--- a/apps/languageWorkbench/examples/dl/grammar.txt
+++ b/apps/languageWorkbench/examples/dl/grammar.txt
@@ -5,11 +5,12 @@ comment :- ["#", repSep(([a-z]|[A-Z]|" "), "")].
 rule :- [record, ws, ":-", ws, repSep(disjunct, [ws, "|", ws])].
 disjunct :- repSep(record, [ws, "&", ws]).
 
-term :- (record | int | var).
+term :- (record | int | var | string).
 var :- [[A-Z], repSep([A-Z], "")].
 record :- [ident, "{", repSep(keyValue, [",", ws]), "}"].
 keyValue :- [ident, ":", ws, term].
 int :- [num, repSep(num, "")].
+string :- ["'", repSep([a-z], ""), "'"].
 
 alpha :- ([a-z] | [A-Z] | "_").
 num :- [0-9].

--- a/apps/languageWorkbench/examples/dl/highlight.dl
+++ b/apps/languageWorkbench/examples/dl/highlight.dl
@@ -1,0 +1,5 @@
+hl.Segment{type: T, span: S, highlight: H} :-
+  hl.ident{type: T, span: S, highlight: H}.
+
+hl.ident{type: "ident", span: S, highlight: false} :-
+  ast.ident{span: S}.

--- a/apps/languageWorkbench/examples/dl/highlight.dl
+++ b/apps/languageWorkbench/examples/dl/highlight.dl
@@ -1,8 +1,11 @@
 hl.Segment{type: T, span: S, highlight: H} :-
   hl.ident{type: T, span: S, highlight: H} |
-  hl.var{type: T, span: S, highlight: H}.
+  hl.var{type: T, span: S, highlight: H} |
+  hl.int{type: T, span: S, highlight: H}.
 
 hl.ident{type: "ident", span: S, highlight: false} :-
   ast.ident{span: S}.
 hl.var{type: "var", span: S, highlight: false} :-
   ast.var{span: S}.
+hl.int{type: "int", span: S, highlight: false} :-
+  ast.int{span: S}.

--- a/apps/languageWorkbench/examples/dl/highlight.dl
+++ b/apps/languageWorkbench/examples/dl/highlight.dl
@@ -1,5 +1,8 @@
 hl.Segment{type: T, span: S, highlight: H} :-
-  hl.ident{type: T, span: S, highlight: H}.
+  hl.ident{type: T, span: S, highlight: H} |
+  hl.var{type: T, span: S, highlight: H}.
 
 hl.ident{type: "ident", span: S, highlight: false} :-
   ast.ident{span: S}.
+hl.var{type: "var", span: S, highlight: false} :-
+  ast.var{span: S}.

--- a/apps/languageWorkbench/examples/dl/highlight.dl
+++ b/apps/languageWorkbench/examples/dl/highlight.dl
@@ -1,7 +1,8 @@
 hl.Segment{type: T, span: S, highlight: H} :-
   hl.ident{type: T, span: S, highlight: H} |
   hl.var{type: T, span: S, highlight: H} |
-  hl.int{type: T, span: S, highlight: H}.
+  hl.int{type: T, span: S, highlight: H} |
+  hl.string{type: T, span: S, highlight: H}.
 
 hl.ident{type: "ident", span: S, highlight: false} :-
   ast.ident{span: S}.
@@ -9,3 +10,6 @@ hl.var{type: "var", span: S, highlight: false} :-
   ast.var{span: S}.
 hl.int{type: "int", span: S, highlight: false} :-
   ast.int{span: S}.
+hl.string{type: "string", span: S, highlight: false} :-
+  ast.string{span: S}.
+

--- a/apps/languageWorkbench/examples/dl/theme.css
+++ b/apps/languageWorkbench/examples/dl/theme.css
@@ -1,0 +1,12 @@
+.segment-ident {
+    color: purple;
+}
+.segment-var {
+    color: orange;
+}
+.segment-int {
+    color: blue;
+}
+.segment-string {
+    color: green;
+}

--- a/apps/languageWorkbench/main.tsx
+++ b/apps/languageWorkbench/main.tsx
@@ -27,6 +27,7 @@ import { nullLoader } from "../../core/loaders";
 import { Explorer } from "../../uiCommon/explorer";
 import { AbstractInterpreter } from "../../core/abstractInterpreter";
 import { uniq } from "../../util/util";
+import { CodeEditor } from "./codeEditor";
 
 function Main() {
   return <Playground />;
@@ -38,7 +39,10 @@ function ErrorList(props: { errors: string[] }) {
   return props.errors.length > 0 ? (
     <ul>
       {uniq(props.errors).map((err) => (
-        <li key={err} style={{ color: "red", fontFamily: "monospace", whiteSpace: "pre" }}>
+        <li
+          key={err}
+          style={{ color: "red", fontFamily: "monospace", whiteSpace: "pre" }}
+        >
           {err}
         </li>
       ))}
@@ -65,6 +69,11 @@ function Playground() {
       "language-workbench-rule-tree-collapse-state",
       emptyCollapseState
     );
+  // TODO: make this not require a string as its value
+  const [cursorPos, setCursorPos] = useLocalStorage(
+    "language-workbench-cursor-pos",
+    "0"
+  );
 
   const grammarTraceTree = parse(metaGrammar, "grammar", grammarSource);
   const grammarRuleTree = extractRuleTree(grammarTraceTree);
@@ -123,12 +132,12 @@ function Playground() {
             </td>
             <td>
               <h3>Language Source</h3>
-              <textarea
-                value={langSource}
-                onChange={(evt) => setLangSource(evt.target.value)}
-                rows={10}
-                cols={50}
-                spellCheck={false}
+              <CodeEditor
+                source={langSource}
+                onSourceChange={setLangSource}
+                cursorPos={parseInt(cursorPos)}
+                onCursorPosChange={(pos) => setCursorPos(pos.toString())}
+                interp={finalInterp}
               />
               <ErrorList errors={langParseError ? [langParseError] : []} />
             </td>
@@ -148,9 +157,6 @@ function Playground() {
       </table>
 
       <>
-        {langParseError ? (
-          <pre style={{ color: "red" }}>{langParseError}</pre>
-        ) : null}
         <Explorer interp={finalInterp} />
 
         {/* TODO: memoize some of these. they take non-trival time to render */}

--- a/apps/languageWorkbench/main.tsx
+++ b/apps/languageWorkbench/main.tsx
@@ -28,6 +28,7 @@ import { Explorer } from "../../uiCommon/explorer";
 import { AbstractInterpreter } from "../../core/abstractInterpreter";
 import { uniq } from "../../util/util";
 import { CodeEditor } from "./codeEditor";
+import { ensureHighlightSegmentTable } from "./util";
 
 function Main() {
   return <Playground />;
@@ -105,6 +106,7 @@ function Playground() {
       flattened = flatten(ruleTree, langSource);
       finalInterp = finalInterp.evalStmts(declareTables(grammar))[1];
       finalInterp = finalInterp.insertAll(flattened);
+      finalInterp = ensureHighlightSegmentTable(finalInterp);
     } catch (e) {
       langParseError = e.toString();
       console.error(e);

--- a/apps/languageWorkbench/main.tsx
+++ b/apps/languageWorkbench/main.tsx
@@ -38,7 +38,7 @@ function ErrorList(props: { errors: string[] }) {
   return props.errors.length > 0 ? (
     <ul>
       {uniq(props.errors).map((err) => (
-        <li key={err} style={{ color: "red", fontFamily: "monospace" }}>
+        <li key={err} style={{ color: "red", fontFamily: "monospace", whiteSpace: "pre" }}>
           {err}
         </li>
       ))}
@@ -117,6 +117,7 @@ function Playground() {
                 onChange={(evt) => setGrammarSource(evt.target.value)}
                 rows={10}
                 cols={50}
+                spellCheck={false}
               />
               <ErrorList errors={allGrammarErrors} />
             </td>
@@ -127,6 +128,7 @@ function Playground() {
                 onChange={(evt) => setLangSource(evt.target.value)}
                 rows={10}
                 cols={50}
+                spellCheck={false}
               />
               <ErrorList errors={langParseError ? [langParseError] : []} />
             </td>
@@ -137,6 +139,7 @@ function Playground() {
                 onChange={(evt) => setDLSource(evt.target.value)}
                 rows={10}
                 cols={50}
+                spellCheck={false}
               />
               <ErrorList errors={dlErrors} />
             </td>

--- a/apps/languageWorkbench/main.tsx
+++ b/apps/languageWorkbench/main.tsx
@@ -65,6 +65,10 @@ function Playground() {
     "language-workbench-dl-source",
     ""
   );
+  const [themeSource, setThemeSource] = useLocalStorage(
+    "language-workbench-theme-source",
+    ""
+  );
   const [ruleTreeCollapseState, setRuleTreeCollapseState] =
     useJSONLocalStorage<TreeCollapseState>(
       "language-workbench-rule-tree-collapse-state",
@@ -153,6 +157,17 @@ function Playground() {
                 spellCheck={false}
               />
               <ErrorList errors={dlErrors} />
+            </td>
+            <td>
+              <h3>Theme Source</h3>
+              <textarea
+                value={themeSource}
+                onChange={(evt) => setThemeSource(evt.target.value)}
+                rows={10}
+                cols={50}
+                spellCheck={false}
+              />
+              <style>{themeSource}</style>
             </td>
           </tr>
         </tbody>

--- a/apps/languageWorkbench/main.tsx
+++ b/apps/languageWorkbench/main.tsx
@@ -21,7 +21,7 @@ import { metaGrammar, extractGrammar } from "../../parserlib/meta";
 import { validateGrammar } from "../../parserlib/validate";
 import { Rec } from "../../core/types";
 import { BareTerm } from "../../uiCommon/dl/replViews";
-import { flatten } from "../../parserlib/flatten";
+import { declareTables, flatten } from "../../parserlib/flatten";
 import { SimpleInterpreter } from "../../core/simple/interpreter";
 import { nullLoader } from "../../core/loaders";
 import { Explorer } from "../../uiCommon/explorer";
@@ -103,9 +103,8 @@ function Playground() {
       traceTree = parse(grammar, "main", langSource);
       ruleTree = extractRuleTree(traceTree);
       flattened = flatten(ruleTree, langSource);
-      flattened.forEach((rec) => {
-        finalInterp = finalInterp.insert(rec) as SimpleInterpreter;
-      });
+      finalInterp = finalInterp.evalStmts(declareTables(grammar))[1];
+      finalInterp = finalInterp.insertAll(flattened);
     } catch (e) {
       langParseError = e.toString();
       console.error(e);

--- a/apps/languageWorkbench/main.tsx
+++ b/apps/languageWorkbench/main.tsx
@@ -139,6 +139,7 @@ function Playground() {
                 cursorPos={parseInt(cursorPos)}
                 onCursorPosChange={(pos) => setCursorPos(pos.toString())}
                 interp={finalInterp}
+                validGrammar={grammarErrors.length === 0}
               />
               <ErrorList errors={langParseError ? [langParseError] : []} />
             </td>
@@ -158,7 +159,12 @@ function Playground() {
       </table>
 
       <>
-        <Explorer interp={finalInterp} />
+        {/* we run into errors querying highlight rules if the grammar isn't valid */}
+        {grammarErrors.length === 0 ? (
+          <Explorer interp={finalInterp} />
+        ) : (
+          <em>Grammar isn't valid</em>
+        )}
 
         {/* TODO: memoize some of these. they take non-trival time to render */}
 

--- a/apps/languageWorkbench/util.ts
+++ b/apps/languageWorkbench/util.ts
@@ -1,0 +1,10 @@
+import { AbstractInterpreter } from "../../core/abstractInterpreter";
+
+export function ensureHighlightSegmentTable(
+  interp: AbstractInterpreter
+): AbstractInterpreter {
+  if (interp.getRules().some((r) => r.head.relation === "hl.Segment")) {
+    return interp;
+  }
+  return interp.evalStmt({ type: "TableDecl", name: "hl.Segment" })[1];
+}

--- a/core/abstractInterpreter.ts
+++ b/core/abstractInterpreter.ts
@@ -32,8 +32,15 @@ export abstract class AbstractInterpreter {
   }
 
   evalStr(str: string): [Res[], AbstractInterpreter] {
-    const stmt = dlLanguage.statement.tryParse(str);
-    return this.evalStmt(stmt);
+    const results: Res[] = [];
+    const stmts = dlLanguage.program.tryParse(str);
+    let curInterp: AbstractInterpreter = this;
+    stmts.forEach((stmt) => {
+      const [newResults, nextInterp] = curInterp.evalStmt(stmt);
+      curInterp = nextInterp;
+      newResults.forEach((res) => results.push(res));
+    })
+    return [results, curInterp];
   }
 
   doLoad(path: string): AbstractInterpreter {

--- a/core/abstractInterpreter.ts
+++ b/core/abstractInterpreter.ts
@@ -15,9 +15,24 @@ export abstract class AbstractInterpreter {
 
   abstract evalStmt(stmt: Statement): [Res[], AbstractInterpreter];
 
+  evalStmts(stmts: Statement[]): [Res[], AbstractInterpreter] {
+    const results: Res[] = [];
+    let interp: AbstractInterpreter = this;
+    stmts.forEach((stmt) => {
+      const [newResults, newInterp] = interp.evalStmt(stmt);
+      newResults.forEach((res) => results.push(res));
+      interp = newInterp;
+    });
+    return [results, interp];
+  }
+
   insert(record: Rec): AbstractInterpreter {
     const [_, newInterp] = this.evalStmt({ type: "Insert", record });
     return newInterp;
+  }
+
+  insertAll(records: Rec[]): AbstractInterpreter {
+    return records.reduce((interp, rec) => interp.insert(rec), this);
   }
 
   queryStr(str: string): Res[] {
@@ -32,15 +47,8 @@ export abstract class AbstractInterpreter {
   }
 
   evalStr(str: string): [Res[], AbstractInterpreter] {
-    const results: Res[] = [];
     const stmts = dlLanguage.program.tryParse(str);
-    let curInterp: AbstractInterpreter = this;
-    stmts.forEach((stmt) => {
-      const [newResults, nextInterp] = curInterp.evalStmt(stmt);
-      curInterp = nextInterp;
-      newResults.forEach((res) => results.push(res));
-    })
-    return [results, curInterp];
+    return this.evalStmts(stmts);
   }
 
   doLoad(path: string): AbstractInterpreter {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build-actors-ui": "esbuild apps/actors/main.tsx --bundle --outfile=apps/actors/public/bundle.js --sourcemap '--define:process.env.NODE_ENV=\"development\"' --loader:.dl=text",
     "serve-actors-ui": "cd apps/actors/public && http-server -c-1",
     "build-language-workbench": "esbuild apps/languageWorkbench/main.tsx --bundle --outfile=apps/languageWorkbench/public/bundle.js '--define:process.env.NODE_ENV=\"development\"' --sourcemap",
-    "serve-language-workbench": "cd apps/languageWorkbench/public && http-server -c-1",
+    "serve-language-workbench": "cd apps/languageWorkbench/public && http-server -c-1 --port=8081",
     "build-incr-parser-playground": "esbuild apps/incrParser/main.tsx --bundle --outfile=apps/incrParser/public/bundle.js '--define:process.env.NODE_ENV=\"development\"' --sourcemap",
     "serve-incr-parser-playground": "cd apps/incrParser/public && http-server -c-1",
     "build-ddtest-viewer": "esbuild util/ddTest/viewer/main.tsx --bundle --outfile=util/ddTest/viewer/public/bundle.js '--define:process.env.NODE_ENV=\"development\"' --sourcemap --external:path --external:fs --external:crypto",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build-actors-ui": "esbuild apps/actors/main.tsx --bundle --outfile=apps/actors/public/bundle.js --sourcemap '--define:process.env.NODE_ENV=\"development\"' --loader:.dl=text",
     "serve-actors-ui": "cd apps/actors/public && http-server -c-1",
     "build-language-workbench": "esbuild apps/languageWorkbench/main.tsx --bundle --outfile=apps/languageWorkbench/public/bundle.js '--define:process.env.NODE_ENV=\"development\"' --sourcemap",
-    "serve-language-workbench": "cd apps/languageWorkbench/public && http-server -c-1 --port=8081",
+    "serve-language-workbench": "cd apps/languageWorkbench/public && http-server -c-1",
     "build-incr-parser-playground": "esbuild apps/incrParser/main.tsx --bundle --outfile=apps/incrParser/public/bundle.js '--define:process.env.NODE_ENV=\"development\"' --sourcemap",
     "serve-incr-parser-playground": "cd apps/incrParser/public && http-server -c-1",
     "build-ddtest-viewer": "esbuild util/ddTest/viewer/main.tsx --bundle --outfile=util/ddTest/viewer/public/bundle.js '--define:process.env.NODE_ENV=\"development\"' --sourcemap --external:path --external:fs --external:crypto",

--- a/parserlib/flatten.ts
+++ b/parserlib/flatten.ts
@@ -1,5 +1,6 @@
-import { rec, int, Rec, Term, str } from "../core/types";
+import { rec, int, Rec, Term, str, Statement } from "../core/types";
 import { groupBy } from "../util/util";
+import { Grammar } from "./grammar";
 import { RuleTree } from "./ruleTree";
 
 type State = {
@@ -7,6 +8,14 @@ type State = {
   nextID: number;
   source: string;
 };
+
+export function declareTables(grammar: Grammar): Statement[] {
+  const stmts: Statement[] = [];
+  Object.keys(grammar).forEach((ruleName) => {
+    stmts.push({ type: "TableDecl", name: `ast.${ruleName}` });
+  });
+  return stmts;
+}
 
 export function flatten(tree: RuleTree, source: string): Rec[] {
   const state: State = {

--- a/util/util.ts
+++ b/util/util.ts
@@ -171,6 +171,10 @@ export function pairsToObj<T>(
   return out;
 }
 
+export function objToPairs<T>(obj: { [key: string]: T }): [string, T][] {
+  return mapObjToList(obj, (k, v) => [k, v]);
+}
+
 export function clamp(n: number, range: [number, number]): number {
   const [min, max] = range;
   if (n < min) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7341/146878052-63460ddb-8736-4e11-8c45-88c26dab7af8.png)

Syntax highlighting on runtime-editable grammar, powered by runtime-editable datalog. Add example trying it on datalog syntax itself.