### PR TITLE
introduce hl.mapping for more highlighting flexibility

### DIFF
--- a/apps/languageWorkbench/commonTheme.css
+++ b/apps/languageWorkbench/commonTheme.css
@@ -10,6 +10,9 @@
 .segment-keyword {
   color: orange;
 }
+.segment-specialVar {
+  color: orange;
+}
 .segment-var {
   color: purple;
 }

--- a/apps/languageWorkbench/dl/highlight.dl
+++ b/apps/languageWorkbench/dl/highlight.dl
@@ -23,12 +23,13 @@ hl.segmentBool{type: "bool", span: S, highlight: false} :-
   astInternal.node{rule: R, span: S}.
 
 # identifiers
-hl.segmentIdent{type: "var", span: S, highlight: false} :-
-  hl.mapping{rule: R, type: "ident"} &
-  astInternal.node{rule: R, parentID: ParamsID, span: S}.
 hl.segmentSpecialVar{type: "specialVar", span: S, highlight: false} :-
   hl.mapping{rule: R, type: "specialVar"} &
   astInternal.node{rule: R, span: S}.
+
+hl.segmentIdent{type: "var", span: S, highlight: false} :-
+  hl.mapping{rule: R, type: "ident"} &
+  astInternal.node{rule: R, parentID: ParamsID, span: S}.
 hl.segmentIdentDefnHL{type: "defn", span: S, highlight: true} :-
   ide.CurrentUsage{defnLoc: S} &
   scope.Defn{span: S}.

--- a/apps/languageWorkbench/dl/highlight.dl
+++ b/apps/languageWorkbench/dl/highlight.dl
@@ -4,22 +4,31 @@ hl.Segment{type: T, span: S, highlight: H} :-
   hl.segmentBool{type: T, span: S, highlight: H} |
   hl.keyword{type: T, span: S, highlight: H} |
   hl.segmentIdent{type: T, span: S, highlight: H} |
+  hl.segmentSpecialVar{type: T, span: S, highlight: H} |
   hl.segmentIdentDefnHL{type: T, span: S, highlight: H} |
   hl.segmentIdentUsageHL{type: T, span: S, highlight: H}.
 
 # primitives
 hl.segmentInt{type: "int", span: S, highlight: false} :-
-  ast.int{span: S}.
+  hl.mapping{rule: R, type: "int"} &
+  astInternal.node{rule: R, span: S}.
 hl.segmentString{type: "string", span: S, highlight: false} :-
-  ast.string{span: S}.
+  hl.mapping{rule: R, type: "string"} &
+  astInternal.node{rule: R, span: S}.
 hl.keyword{type: "keyword", span: S, highlight: false} :-
-  ast.keyword{span: S}.
+  hl.mapping{rule: R, type: "keyword"} &
+  astInternal.node{rule: R, span: S}.
 hl.segmentBool{type: "bool", span: S, highlight: false} :-
-  ast.bool{span: S}.
+  hl.mapping{rule: R, type: "bool"} &
+  astInternal.node{rule: R, span: S}.
 
 # identifiers
 hl.segmentIdent{type: "var", span: S, highlight: false} :-
-  ast.ident{parentID: ParamsID, span: S}.
+  hl.mapping{rule: R, type: "ident"} &
+  astInternal.node{rule: R, parentID: ParamsID, span: S}.
+hl.segmentSpecialVar{type: "specialVar", span: S, highlight: false} :-
+  hl.mapping{rule: R, type: "specialVar"} &
+  astInternal.node{rule: R, span: S}.
 hl.segmentIdentDefnHL{type: "defn", span: S, highlight: true} :-
   ide.CurrentUsage{defnLoc: S} &
   scope.Defn{span: S}.

--- a/apps/languageWorkbench/examples/basicBlocks/language.dl
+++ b/apps/languageWorkbench/examples/basicBlocks/language.dl
@@ -1,8 +1,3 @@
-ast.keyword{span: S} :-
-  ast.gotoKW{span: S}.
-
-# === Scope ===
-
 scope.Scope{id: I, label: L} :-
   scope.scopeInstr{id: I, label: L} |
   scope.scopeBlock{id: I, label: L}.
@@ -73,3 +68,11 @@ scope.placeholderValue{span: S, scopeID: I, kind: "value"} :-
 scope.placeholderLabel{span: S, scopeID: I, kind: "label"} :-
   ast.Placeholder{id: PlaceholderID, parentID: GotoInstrID, span: S} &
   ast.gotoInstr{id: GotoInstrID, parentID: I}.
+
+# === highlighting ===
+
+hl.mapping{rule: "gotoKW", type: "keyword"}.
+hl.mapping{rule: "int", type: "int"}.
+hl.mapping{rule: "string", type: "string"}.
+hl.mapping{rule: "bool", type: "bool"}.
+hl.mapping{rule: "ident", type: "ident"}.

--- a/apps/languageWorkbench/examples/dl/language.dl
+++ b/apps/languageWorkbench/examples/dl/language.dl
@@ -34,3 +34,9 @@ scope.varTerm{scopeID: I, name: N, span: S, kind: "var"} :-
   ast.keyValue{id: KeyValueID, parentID: RecordID} &
   ast.term{id: ValueTermID, parentID: KeyValueID} &
   ast.var{parentID: ValueTermID, text: N, span: S}.
+
+hl.mapping{rule: "ident", type: "ident"}.
+hl.mapping{rule: "var", type: "specialVar"}.
+hl.mapping{rule: "int", type: "int"}.
+hl.mapping{rule: "bool", type: "bool"}.
+hl.mapping{rule: "string", type: "string"}.

--- a/apps/languageWorkbench/examples/json/language.dl
+++ b/apps/languageWorkbench/examples/json/language.dl
@@ -1,0 +1,3 @@
+hl.mapping{rule: "int", type: "int"}.
+hl.mapping{rule: "string", type: "string"}.
+hl.mapping{rule: "bool", type: "bool"}.

--- a/apps/languageWorkbench/requiredRelations.ts
+++ b/apps/languageWorkbench/requiredRelations.ts
@@ -2,11 +2,7 @@ import { AbstractInterpreter } from "../../core/abstractInterpreter";
 
 // this is the closest we've come thus far to specifying an API...
 const REQUIRED_RELATIONS = [
-  "ast.keyword",
-  "ast.ident",
-  "ast.string",
-  "ast.int",
-  "ast.bool",
+  "hl.mapping",
   "scope.Scope",
   "scope.Defn",
   "scope.Var",


### PR DESCRIPTION
Layer of indirection between rule names and how they're highlighted.

![image](https://user-images.githubusercontent.com/7341/151179669-1a9655c8-596e-43d2-a4ea-1f53ce23d0c5.png)

Next up: probably use scope.Var and scope.Defn with `kind` for highlighting different types of vars
Plus, still need to highlight all usages of a variable.