### PR TITLE
highlight comments in datalog

### DIFF
--- a/apps/languageWorkbench/commonTheme.css
+++ b/apps/languageWorkbench/commonTheme.css
@@ -28,3 +28,6 @@
 .segment-usage__highlighted {
   background-color: rgba(168, 168, 168, 0.37);
 }
+.segment-comment {
+  color: darkgrey;
+}

--- a/apps/languageWorkbench/examples/dl/datalog.dl
+++ b/apps/languageWorkbench/examples/dl/datalog.dl
@@ -56,3 +56,4 @@ hl.mapping{rule: "var", type: "specialVar"}.
 hl.mapping{rule: "int", type: "int"}.
 hl.mapping{rule: "bool", type: "bool"}.
 hl.mapping{rule: "string", type: "string"}.
+hl.mapping{rule: "comment", type: "comment"}.

--- a/apps/languageWorkbench/examples/dl/datalog.grammar
+++ b/apps/languageWorkbench/examples/dl/datalog.grammar
@@ -1,10 +1,11 @@
 main :- repSep((stmt | comment), ws).
-stmt :- [(rule | fact), "."].
-comment :- ["#", repSep(([a-z]|[A-Z]|" "), "")].
+stmt :- (rule | fact | tableDecl).
+comment :- ["#", repSep(([A-Z] | [a-z] | " " | ":" | "."), "")].
+tableDecl :- [".table", ws, ident].
 
-fact :- record.
+fact :- [record, "."].
 
-rule :- [record, ws, ":-", ws, repSep(disjunct, [ws, "|", ws])].
+rule :- [record, ws, ":-", ws, repSep(disjunct, [ws, "|", ws]), "."].
 disjunct :- repSep(record, [ws, "&", ws]).
 
 term :- (record | int | var | string | bool | placeholder).

--- a/uiCommon/ide/datalogPowered/dl/highlight.dl
+++ b/uiCommon/ide/datalogPowered/dl/highlight.dl
@@ -6,7 +6,8 @@ hl.Segment{type: T, span: S, highlight: H} :-
   hl.segmentIdent{type: T, span: S, highlight: H} |
   hl.segmentSpecialVar{type: T, span: S, highlight: H} |
   hl.segmentIdentDefnHL{type: T, span: S, highlight: H} |
-  hl.segmentIdentUsageHL{type: T, span: S, highlight: H}.
+  hl.segmentIdentUsageHL{type: T, span: S, highlight: H} |
+  hl.segmentComment{type: T, span: S, highlight: H}.
 
 # primitives
 hl.segmentInt{type: "int", span: S, highlight: false} :-
@@ -20,6 +21,9 @@ hl.keyword{type: "keyword", span: S, highlight: false} :-
   astInternal.node{rule: R, span: S}.
 hl.segmentBool{type: "bool", span: S, highlight: false} :-
   hl.mapping{rule: R, type: "bool"} &
+  astInternal.node{rule: R, span: S}.
+hl.segmentComment{type: "comment", span: S, highlight: false} :-
+  hl.mapping{rule: R, type: "comment"} &
   astInternal.node{rule: R, span: S}.
 
 # identifiers


### PR DESCRIPTION
TODO: allow more types of characters in comments.

meta grammar bug: can't parse `\n` as a character.