### PR TITLE
Perf timeline

### DIFF
--- a/apps/languageWorkbench/main.tsx
+++ b/apps/languageWorkbench/main.tsx
@@ -25,12 +25,9 @@ function Main() {
 
 function Playground() {
   // state
-  const [exampleName, setExampleName] = useHashParam(
-    "",
-    Object.keys(EXAMPLES)[0]
-  );
+  const [langName, setExampleName] = useHashParam("", Object.keys(EXAMPLES)[0]);
 
-  const curExample = EXAMPLES[exampleName];
+  const curExample = EXAMPLES[langName];
 
   const [grammarEditorState, setGrammarEditorState] = useState(
     initialEditorState(curExample.grammar)
@@ -61,7 +58,7 @@ function Playground() {
     [cursorPos, dlEditorState.source, grammarEditorState.source, langSource]
   );
 
-  const setExample = (name) => {
+  const setLangName = (name) => {
     setExampleName(name);
     const example = EXAMPLES[name];
     setGrammarEditorState({ ...grammarEditorState, source: example.grammar });
@@ -77,9 +74,9 @@ function Playground() {
         <h3>Example:</h3>
         <select
           onChange={(evt) => {
-            setExample(evt.target.value);
+            setLangName(evt.target.value);
           }}
-          value={exampleName}
+          value={langName}
         >
           {mapObjToList(EXAMPLES, (name) => (
             <option key={name} value={name}>
@@ -100,6 +97,7 @@ function Playground() {
                 interp={finalInterp}
                 validGrammar={allGrammarErrors.length === 0}
                 highlightCSS={commonThemeCSS}
+                lang={langName}
                 locatedErrors={[]} // TODO: parse errors
               />
               <ErrorList errors={langParseError ? [langParseError] : []} />
@@ -112,6 +110,7 @@ function Playground() {
                 datalog={EXAMPLES.grammar.datalog}
                 grammar={EXAMPLES.grammar.grammar}
                 highlightCSS={commonThemeCSS}
+                lang="grammar"
                 hideKeyBindingsTable
               />
               <ErrorList errors={allGrammarErrors} />
@@ -124,6 +123,7 @@ function Playground() {
                 datalog={EXAMPLES.datalog.datalog}
                 grammar={EXAMPLES.datalog.grammar}
                 highlightCSS={commonThemeCSS}
+                lang="dl"
                 hideKeyBindingsTable
               />
               <ErrorList errors={dlErrors} />

--- a/core/incremental/fastPPT.ts
+++ b/core/incremental/fastPPT.ts
@@ -17,7 +17,7 @@ export function fastPPT(term: Term): string {
     case "Bool":
       return term.val.toString();
     case "StringLit":
-      return term.val;
+      return `"${term.val}"`;
     case "IntLit":
       return term.val.toString();
     case "Var":

--- a/core/incremental/fastPPT.ts
+++ b/core/incremental/fastPPT.ts
@@ -1,5 +1,12 @@
 import { mapObjToListUnordered } from "../../util/util";
-import { Term } from "../types";
+import { Bindings, Term } from "../types";
+
+export function fastPPB(bindings: Bindings) {
+  return `{${mapObjToListUnordered(
+    bindings,
+    (k, v) => `${k}: ${fastPPT(v)}`
+  ).join(", ")}}`;
+}
 
 export function fastPPT(term: Term): string {
   switch (term.type) {

--- a/core/simple/simpleEvaluate.ts
+++ b/core/simple/simpleEvaluate.ts
@@ -155,6 +155,7 @@ function doEvaluate(
         }
         const rule = db.rules[term.relation];
         if (rule) {
+          performance.mark(`${term.relation} start`);
           // console.log(
           //   "calling",
           //   pp.render(100, [
@@ -199,7 +200,7 @@ function doEvaluate(
           });
           // console.groupEnd();
           // console.log("rawResults", rawResults.map(ppr));
-          return filterMap(rawResults, (res) => {
+          const finalRes = filterMap(rawResults, (res) => {
             const mappedBindings = applyMappings(mappings, res.bindings);
             const nextTerm = substitute(rule.head, res.bindings);
             const unif = unify(mappedBindings, term, nextTerm);
@@ -235,6 +236,13 @@ function doEvaluate(
             };
             return outerRes;
           });
+          performance.mark(`${term.relation} end`);
+          performance.measure(
+            term.relation,
+            `${term.relation} start`,
+            `${term.relation} end`
+          );
+          return finalRes;
         }
         throw new UserError(`not found: ${term.relation}`);
       }

--- a/core/simple/simpleEvaluate.ts
+++ b/core/simple/simpleEvaluate.ts
@@ -129,9 +129,6 @@ function doEvaluate(
         const virtual = db.virtualTables[term.relation];
         const records = table ? table : virtual ? virtual(db) : null;
         if (records) {
-          const s = `${term.relation} start`;
-          const e = `${term.relation} end`;
-          performance.mark(s);
           const out: Res[] = [];
           // console.log("scan", term.relation, ppb(scope));
           for (const rec of records) {
@@ -155,12 +152,6 @@ function doEvaluate(
               },
             });
           }
-          performance.mark(e);
-          performance.measure(
-            `scan ${term.relation}${fastPPB(scope)} => ${out.length}`,
-            s,
-            e
-          );
           return out;
         }
         const rule = db.rules[term.relation];

--- a/core/simple/simpleEvaluate.ts
+++ b/core/simple/simpleEvaluate.ts
@@ -26,6 +26,7 @@ import { filterMap, flatMap, repeat } from "../../util/util";
 import { evalBinExpr, extractBinExprs } from "../binExpr";
 import { ppb, ppt } from "../pretty";
 import { fastPPB } from "../incremental/fastPPT";
+import { perfMark, perfMeasure } from "../../util/perf";
 
 export function evaluate(db: DB, term: Term): Res[] {
   return doEvaluate(0, [], db, {}, term);
@@ -158,7 +159,7 @@ function doEvaluate(
         if (rule) {
           const s = `${term.relation} start`;
           const e = `${term.relation} end`;
-          performance.mark(s);
+          perfMark(s);
           // console.log(
           //   "calling",
           //   pp.render(100, [
@@ -239,8 +240,8 @@ function doEvaluate(
             };
             return outerRes;
           });
-          performance.mark(e);
-          performance.measure(
+          perfMark(e);
+          perfMeasure(
             `${term.relation}${fastPPB(scope)} => ${finalRes.length}`,
             s,
             e

--- a/core/simple/simpleEvaluate.ts
+++ b/core/simple/simpleEvaluate.ts
@@ -157,9 +157,9 @@ function doEvaluate(
         }
         const rule = db.rules[term.relation];
         if (rule) {
-          const s = `${term.relation} start`;
-          const e = `${term.relation} end`;
-          perfMark(s);
+          if (perf) {
+            perfMark(`${term.relation} start`);
+          }
           // console.log(
           //   "calling",
           //   pp.render(100, [
@@ -240,12 +240,15 @@ function doEvaluate(
             };
             return outerRes;
           });
-          perfMark(e);
-          perfMeasure(
-            `${term.relation}${fastPPB(scope)} => ${finalRes.length}`,
-            s,
-            e
-          );
+          if (perf) {
+            const e = `${term.relation} end`;
+            perfMark(e);
+            perfMeasure(
+              `${term.relation}${fastPPB(scope)} => ${finalRes.length}`,
+              `${term.relation} start`,
+              e
+            );
+          }
           return finalRes;
         }
         throw new UserError(`not found: ${term.relation}`);
@@ -283,4 +286,19 @@ export function hasVars(t: Term): boolean {
     case "Bool":
       return false;
   }
+}
+
+// enable marking datalog rules on the Chrome devtools performance timeline
+let perf = false;
+
+if (typeof window !== "undefined") {
+  // @ts-ignore
+  window.enablePerf = () => {
+    perf = true;
+  };
+
+  // @ts-ignore
+  window.disablePerf = () => {
+    perf = false;
+  };
 }

--- a/uiCommon/ide/datalogPowered/openCodeEditor.tsx
+++ b/uiCommon/ide/datalogPowered/openCodeEditor.tsx
@@ -17,7 +17,6 @@ export function OpenCodeEditor(props: {
   hideKeyBindingsTable?: boolean;
 }) {
   const { highlighted, error, suggestions } = React.useMemo(() => {
-    console.log(`highlighting for ${props.lang}`);
     let highlighted: React.ReactNode = <>{props.editorState.source}</>;
     let error = null;
     let suggestions: Suggestion[] = [];

--- a/uiCommon/ide/datalogPowered/openCodeEditor.tsx
+++ b/uiCommon/ide/datalogPowered/openCodeEditor.tsx
@@ -13,13 +13,20 @@ export function OpenCodeEditor(props: {
   validGrammar: boolean;
   highlightCSS: string;
   locatedErrors: { offset: number }[];
+  lang: string;
   hideKeyBindingsTable?: boolean;
 }) {
   let highlighted: React.ReactNode = <>{props.editorState.source}</>;
   let error = null;
   if (props.validGrammar) {
     try {
-      highlighted = highlight(props.interp, props.editorState.source, 0, []);
+      highlighted = highlight(
+        props.interp,
+        props.editorState.source,
+        0,
+        [],
+        props.lang
+      );
     } catch (e) {
       error = e.toString();
     }

--- a/uiCommon/ide/datalogPowered/openCodeEditor.tsx
+++ b/uiCommon/ide/datalogPowered/openCodeEditor.tsx
@@ -16,27 +16,33 @@ export function OpenCodeEditor(props: {
   lang: string;
   hideKeyBindingsTable?: boolean;
 }) {
-  let highlighted: React.ReactNode = <>{props.editorState.source}</>;
-  let error = null;
-  if (props.validGrammar) {
-    try {
-      highlighted = highlight(
-        props.interp,
-        props.editorState.source,
-        0,
-        [],
-        props.lang
-      );
-    } catch (e) {
-      error = e.toString();
+  const { highlighted, error, suggestions } = React.useMemo(() => {
+    console.log(`highlighting for ${props.lang}`);
+    let highlighted: React.ReactNode = <>{props.editorState.source}</>;
+    let error = null;
+    let suggestions: Suggestion[] = [];
+    if (props.validGrammar) {
+      try {
+        highlighted = highlight(
+          props.interp,
+          props.editorState.source,
+          0,
+          [],
+          props.lang
+        );
+        suggestions = getSuggestions(props.interp);
+      } catch (e) {
+        error = e.toString();
+      }
     }
-  }
+    return { highlighted, error, suggestions };
+  }, [props.interp, props.editorState.source, props.lang]);
 
-  let suggestions: Suggestion[] = [];
-  try {
-    suggestions = getSuggestions(props.interp);
-  } catch (e) {
-    console.warn("error while getting suggestions:", e);
+  if (error) {
+    console.error(
+      `while highlighting and getting suggestions for ${props.lang}:`,
+      error
+    );
   }
 
   const actionCtx: ActionContext = {

--- a/uiCommon/ide/datalogPowered/wrappedCodeEditor.tsx
+++ b/uiCommon/ide/datalogPowered/wrappedCodeEditor.tsx
@@ -17,6 +17,7 @@ export function WrappedCodeEditor(props: {
   highlightCSS: string;
   editorState: EditorState;
   setEditorState: (st: EditorState) => void;
+  lang: string;
   hideKeyBindingsTable?: boolean;
 }) {
   const { finalInterp, allGrammarErrors, langParseError, dlErrors } = useMemo(
@@ -47,6 +48,7 @@ export function WrappedCodeEditor(props: {
         locatedErrors={[]} // TODO: parse errors, dl errors
         validGrammar={allGrammarErrors.length === 0}
         hideKeyBindingsTable={props.hideKeyBindingsTable}
+        lang={props.lang}
       />
       <ErrorList
         errors={[langParseError, ...dlErrors].filter((x) => x !== null)}

--- a/uiCommon/ide/datalogPowered/wrappedCodeEditor.tsx
+++ b/uiCommon/ide/datalogPowered/wrappedCodeEditor.tsx
@@ -20,23 +20,23 @@ export function WrappedCodeEditor(props: {
   lang: string;
   hideKeyBindingsTable?: boolean;
 }) {
-  const { finalInterp, allGrammarErrors, langParseError, dlErrors } = useMemo(
-    () =>
-      constructInterp({
+  const { finalInterp, allGrammarErrors, langParseError, dlErrors } =
+    useMemo(() => {
+      console.log("constructing interp for language", props.lang);
+      return constructInterp({
         initInterp,
         builtinSource: mainDL,
         grammarSource: props.grammar,
         cursorPos: props.editorState.cursorPos,
         dlSource: props.datalog,
         langSource: props.editorState.source,
-      }),
-    [
+      });
+    }, [
       props.grammar,
       props.editorState.cursorPos,
       props.datalog,
       props.editorState.source,
-    ]
-  );
+    ]);
 
   return (
     <>

--- a/uiCommon/ide/datalogPowered/wrappedCodeEditor.tsx
+++ b/uiCommon/ide/datalogPowered/wrappedCodeEditor.tsx
@@ -22,7 +22,6 @@ export function WrappedCodeEditor(props: {
 }) {
   const { finalInterp, allGrammarErrors, langParseError, dlErrors } =
     useMemo(() => {
-      console.log("constructing interp for language", props.lang);
       return constructInterp({
         initInterp,
         builtinSource: mainDL,

--- a/uiCommon/ide/highlight.tsx
+++ b/uiCommon/ide/highlight.tsx
@@ -10,14 +10,18 @@ export function highlight(
   interp: AbstractInterpreter,
   code: string,
   syntaxErrorIdx: number | null,
-  typeErrors: DLTypeError[]
+  typeErrors: DLTypeError[],
+  lang: string
 ): React.ReactNode {
   if (syntaxErrorIdx) {
     return highlightSyntaxError(code, syntaxErrorIdx);
   }
+  performance.mark("highlight start");
   const segments = interp.queryStr(
     "hl.Segment{type: T, span: S, highlight: H}"
   );
+  performance.mark("highlight end");
+  performance.measure(`highlight ${lang}`, "highlight start", "highlight end");
   const sortedSegments = hlWins(
     uniqBy(
       segments

--- a/uiCommon/ide/parsimmonPowered/codeEditor.tsx
+++ b/uiCommon/ide/parsimmonPowered/codeEditor.tsx
@@ -49,6 +49,7 @@ export function CodeEditor(props: {
   editorState: EditorState;
   setEditorState: (st: EditorState) => void;
   loadError: EvalError | null;
+  lang: string;
 }) {
   let evalError: EvalError | null = null;
   let suggestions: Suggestion[] = [];
@@ -87,7 +88,8 @@ export function CodeEditor(props: {
     props.loadError && props.loadError.type === "ParseError"
       ? props.loadError.offset
       : null,
-    typeErrors
+    typeErrors,
+    props.lang
   );
 
   return (

--- a/util/perf.ts
+++ b/util/perf.ts
@@ -1,11 +1,11 @@
 export function perfMark(key: string) {
-  if (performance) {
+  if (typeof performance !== "undefined") {
     performance.mark(key);
   }
 }
 
 export function perfMeasure(key: string, start: string, end: string) {
-  if (performance) {
+  if (typeof performance !== "undefined") {
     performance.measure(key, start, end);
   }
 }

--- a/util/perf.ts
+++ b/util/perf.ts
@@ -1,0 +1,11 @@
+export function perfMark(key: string) {
+  if (performance) {
+    performance.mark(key);
+  }
+}
+
+export function perfMeasure(key: string, start: string, end: string) {
+  if (performance) {
+    performance.measure(key, start, end);
+  }
+}


### PR DESCRIPTION
Use `performance.mark` to see datalog rules on the chrome devtools timeline.

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/7341/159932685-c1e4ba8e-a957-4ec3-b93a-53b1426d13f1.png">
