### PR TITLE
Vscode completions

### DIFF
--- a/apps/vscodeExtension/engine.ts
+++ b/apps/vscodeExtension/engine.ts
@@ -84,11 +84,6 @@ export function getHighlights(
   });
 }
 
-export interface MyCompletionItem extends vscode.CompletionItem {
-  label: string;
-  range: vscode.Range;
-}
-
 export function getCompletionItems(
   doc: vscode.TextDocument,
   position: vscode.Position,
@@ -105,12 +100,12 @@ export function getCompletionItems(
   const results = interp2.queryStr(
     `ide.CurrentSuggestion{name: N, span: S, type: T}`
   );
-  console.log("getCompletionItems", results);
+  console.log("getCompletionItems", { position, results });
   return results.map((res) => {
     const result = res.term as Rec;
     const label = result.attrs.name as StringLit;
     const range = spanToRange(source, result.attrs.span as Rec);
-    return new vscode.CompletionItem(label.val);
+    return { label: label.val, range };
   });
 }
 

--- a/apps/vscodeExtension/engine.ts
+++ b/apps/vscodeExtension/engine.ts
@@ -84,6 +84,27 @@ export function getHighlights(
   });
 }
 
+export function getCompletionItems(
+  doc: vscode.TextDocument,
+  position: vscode.Position,
+  token: vscode.CancellationToken,
+  context: vscode.CompletionContext
+): vscode.ProviderResult<vscode.CompletionItem[]> {
+  const source = doc.getText();
+  const interp = getInterp(LANGUAGES.datalog, source);
+  const idx = idxFromLineAndCol(source, {
+    line: position.line,
+    col: position.character,
+  });
+  const interp2 = interp.evalStr(`ide.Cursor{idx: ${idx}}.`)[1];
+  const results = interp2.queryStr(`ide.CurrentSuggestion{}`);
+  return results.map((res) => {
+    const result = res.term as Rec;
+    const label = result.attrs.name as StringLit;
+    return new vscode.CompletionItem(label.val);
+  });
+}
+
 export function refreshDiagnostics(
   doc: vscode.TextDocument,
   diagnostics: vscode.DiagnosticCollection

--- a/apps/vscodeExtension/engine.ts
+++ b/apps/vscodeExtension/engine.ts
@@ -3,7 +3,7 @@ import { SimpleInterpreter } from "../../core/simple/interpreter";
 import { constructInterp } from "../../languageWorkbench/interp";
 import { LANGUAGES, LanguageSpec } from "../../languageWorkbench/languages";
 import { LOADER, mainDL } from "../../languageWorkbench/common";
-import { Rec, Res, StringLit } from "../../core/types";
+import { Rec, StringLit } from "../../core/types";
 import { dlToSpan } from "../../uiCommon/ide/types";
 import { ppt } from "../../core/pretty";
 import {
@@ -84,7 +84,7 @@ export function getHighlights(
   });
 }
 
-export interface BasicCompletionItem extends vscode.CompletionItem {
+export interface MyCompletionItem extends vscode.CompletionItem {
   label: string;
   range: vscode.Range;
 }
@@ -94,7 +94,7 @@ export function getCompletionItems(
   position: vscode.Position,
   token: vscode.CancellationToken,
   context: vscode.CompletionContext
-): vscode.ProviderResult<BasicCompletionItem[]> {
+): vscode.ProviderResult<vscode.CompletionItem[]> {
   const source = doc.getText();
   const interp = getInterp(LANGUAGES.datalog, source);
   const idx = idxFromLineAndCol(source, {
@@ -110,10 +110,7 @@ export function getCompletionItems(
     const result = res.term as Rec;
     const label = result.attrs.name as StringLit;
     const range = spanToRange(source, result.attrs.span as Rec);
-    return {
-      label: label.val,
-      range,
-    };
+    return new vscode.CompletionItem(label.val);
   });
 }
 

--- a/apps/vscodeExtension/engine.ts
+++ b/apps/vscodeExtension/engine.ts
@@ -91,11 +91,13 @@ export function getCompletionItems(
   context: vscode.CompletionContext
 ): vscode.ProviderResult<vscode.CompletionItem[]> {
   const source = doc.getText();
-  const interp = getInterp(LANGUAGES.datalog, source);
   const idx = idxFromLineAndCol(source, {
     line: position.line,
     col: position.character,
   });
+  const sourceWithPlaceholder =
+    source.slice(0, idx) + "???" + source.slice(idx);
+  const interp = getInterp(LANGUAGES.datalog, sourceWithPlaceholder);
   const interp2 = interp.evalStr(`ide.Cursor{idx: ${idx}}.`)[1];
   const results = interp2.queryStr(
     `ide.CurrentSuggestion{name: N, span: S, type: T}`
@@ -105,7 +107,9 @@ export function getCompletionItems(
     const result = res.term as Rec;
     const label = result.attrs.name as StringLit;
     const range = spanToRange(source, result.attrs.span as Rec);
-    return { label: label.val, range };
+    return {
+      label: label.val,
+    };
   });
 }
 

--- a/apps/vscodeExtension/extension.ts
+++ b/apps/vscodeExtension/extension.ts
@@ -4,6 +4,7 @@ import {
   getDefinition,
   getHighlights,
   getReferences,
+  BasicCompletionItem,
   refreshDiagnostics,
 } from "./engine";
 
@@ -75,8 +76,14 @@ export function activate(context: vscode.ExtensionContext) {
         position: vscode.Position,
         token: vscode.CancellationToken,
         context: vscode.CompletionContext
-      ): vscode.ProviderResult<vscode.CompletionItem[]> {
-        return getCompletionItems(document, position, token, context);
+      ): vscode.ProviderResult<BasicCompletionItem[]> {
+        try {
+          const items = getCompletionItems(document, position, token, context);
+          console.log({ items });
+          return items;
+        } catch (e) {
+          console.error("in completion provider:", e);
+        }
       },
     })
   );

--- a/apps/vscodeExtension/extension.ts
+++ b/apps/vscodeExtension/extension.ts
@@ -4,7 +4,6 @@ import {
   getDefinition,
   getHighlights,
   getReferences,
-  MyCompletionItem,
   refreshDiagnostics,
 } from "./engine";
 

--- a/apps/vscodeExtension/extension.ts
+++ b/apps/vscodeExtension/extension.ts
@@ -78,7 +78,6 @@ export function activate(context: vscode.ExtensionContext) {
       ): vscode.ProviderResult<vscode.CompletionItem[]> {
         try {
           const items = getCompletionItems(document, position, token, context);
-          console.log({ items });
           return items;
         } catch (e) {
           console.error("in completion provider:", e);

--- a/apps/vscodeExtension/extension.ts
+++ b/apps/vscodeExtension/extension.ts
@@ -4,7 +4,7 @@ import {
   getDefinition,
   getHighlights,
   getReferences,
-  BasicCompletionItem,
+  MyCompletionItem,
   refreshDiagnostics,
 } from "./engine";
 
@@ -76,7 +76,7 @@ export function activate(context: vscode.ExtensionContext) {
         position: vscode.Position,
         token: vscode.CancellationToken,
         context: vscode.CompletionContext
-      ): vscode.ProviderResult<BasicCompletionItem[]> {
+      ): vscode.ProviderResult<vscode.CompletionItem[]> {
         try {
           const items = getCompletionItems(document, position, token, context);
           console.log({ items });

--- a/apps/vscodeExtension/extension.ts
+++ b/apps/vscodeExtension/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import {
+  getCompletionItems,
   getDefinition,
   getHighlights,
   getReferences,
@@ -66,7 +67,19 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  // TODO: completions
+  // completions
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider("datalog", {
+      provideCompletionItems(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token: vscode.CancellationToken,
+        context: vscode.CompletionContext
+      ): vscode.ProviderResult<vscode.CompletionItem[]> {
+        return getCompletionItems(document, position, token, context);
+      },
+    })
+  );
 }
 
 function subscribeToChanges(


### PR DESCRIPTION
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/7341/166870700-f1db21c2-cda6-4d6d-83fd-c87558686cc0.png">
For DL, what we really need to make this work is to have placeholders for entire clauses and KeyValues…

i.e. request completions and it gives you the whole record, with empty `{}` (or all the `{}` filled in!) not just the name of the record. This will involve refactoring the grammar a bit.