### PR TITLE
Fix datalog scoping rules

### DIFF
--- a/apps/vscodeExtension/package.json
+++ b/apps/vscodeExtension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lingo",
   "displayName": "Lingo",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/vilterp/datalog-ts"

--- a/languageWorkbench/commonDL/astViz.dl
+++ b/languageWorkbench/commonDL/astViz.dl
@@ -7,8 +7,7 @@ astInternal.ruleTreeNode{id: ID, parentID: PID, display: D} :-
 astInternal.ruleTreeNodeBefore{
   id: ID,
   parentID: PID,
-  display: [ID, R, [F, T]],
-  seq: Seq
+  display: [ID, R, [F, T]]
 } :-
   astInternal.node{id: ID, parentID: PID, rule: R, span: span{from: F, to: T}} &
   ide.Cursor{idx: Idx} &
@@ -18,8 +17,7 @@ astInternal.ruleTreeNodeBefore{
 astInternal.ruleTreeNodeAfter{
   id: ID,
   parentID: PID,
-  display: [ID, R, [F, T]],
-  seq: Seq
+  display: [ID, R, [F, T]]
 } :-
   astInternal.node{id: ID, parentID: PID, rule: R, span: span{from: F, to: T}} &
   ide.Cursor{idx: Idx} &
@@ -29,8 +27,7 @@ astInternal.ruleTreeNodeAfter{
 astInternal.ruleTreeNodeCur{
   id: ID,
   parentID: PID,
-  display: [ID, R, [F, T], "*"],
-  seq: Seq
+  display: [ID, R, [F, T], "*"]
 } :-
   astInternal.node{id: ID, parentID: PID, rule: R, span: span{from: F, to: T}} &
   ide.Cursor{idx: Idx} &

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -44,6 +44,21 @@ foo{id: F, span: span{from: F}, spanArr: [F]} :-
   from{id: F} &
   !something{pos: F} &
   F != F.
+scope.Defn{}
+----
+application/datalog
+scope.Defn{kind: "relation", name: "foo", scopeID: global{}, span: span{from: 0, to: 3}}
+scope.Defn{kind: "var", name: "F", scopeID: 3, span: span{from: 8, to: 9}}
+scope.Defn{kind: "var", name: "F", scopeID: 3, span: span{from: 28, to: 29}}
+scope.Defn{kind: "attr", name: "id", scopeID: "foo", span: span{from: 4, to: 6}}
+scope.Defn{kind: "attr", name: "span", scopeID: "foo", span: span{from: 11, to: 15}}
+scope.Defn{kind: "attr", name: "spanArr", scopeID: "foo", span: span{from: 32, to: 39}}
+
+dl
+foo{id: F, span: span{from: F}, spanArr: [F]} :-
+  from{id: F} &
+  !something{pos: F} &
+  F != F.
 scope.Var{}
 ----
 application/datalog
@@ -68,6 +83,11 @@ application/datalog
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 70, to: 71}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 92, to: 93}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 122, to: 123}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 28, to: 29}, kind: "var", name: "F", usageScopeID: 3, usageSpan: span{from: 78, to: 79}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 28, to: 29}, kind: "var", name: "F", usageScopeID: 3, usageSpan: span{from: 137, to: 138}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 35, to: 36}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 100, to: 101}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 35, to: 36}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 130, to: 131}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 35, to: 36}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 142, to: 143}}
 
 dl
 scope.Defn{scopeID: I, name: N, type: T, span: S} :-
@@ -289,6 +309,9 @@ scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3028, to: 3029}, kind:
 scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3037, to: 3038}, kind: "var", name: "T", usageScopeID: 4388, usageSpan: span{from: 3148, to: 3149}}
 scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3170, to: 3171}, kind: "var", name: "I", usageScopeID: 4588, usageSpan: span{from: 3219, to: 3220}}
 scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3170, to: 3171}, kind: "var", name: "I", usageScopeID: 4588, usageSpan: span{from: 3254, to: 3255}}
+scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3190, to: 3191}, kind: "var", name: "F", usageScopeID: 4588, usageSpan: span{from: 3315, to: 3316}}
+scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3197, to: 3198}, kind: "var", name: "R", usageScopeID: 4588, usageSpan: span{from: 3266, to: 3267}}
+scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3197, to: 3198}, kind: "var", name: "R", usageScopeID: 4588, usageSpan: span{from: 3343, to: 3344}}
 scope.Usage{definitionScopeID: 4872, defnSpan: span{from: 3370, to: 3371}, kind: "var", name: "I", usageScopeID: 4872, usageSpan: span{from: 3408, to: 3409}}
 scope.Usage{definitionScopeID: 4872, defnSpan: span{from: 3370, to: 3371}, kind: "var", name: "I", usageScopeID: 4872, usageSpan: span{from: 3448, to: 3449}}
 scope.Usage{definitionScopeID: "scope.builtin", defnSpan: span{from: 229, to: 231}, kind: "attr", name: "id", usageScopeID: "scope.builtin", usageSpan: span{from: 69, to: 71}}

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -36,6 +36,7 @@ dl
 foo{id: I, span: span{from: F, to: T}} :-
   from{id: I, pos: F} &
   to{id: I, pos: T} &
+  !something{id: I, pos: T} &
   F != T.
 scope.Usage{}
 ----

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -43,6 +43,7 @@ scope.Usage{}
 application/datalog
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 70, to: 71}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 92, to: 93}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 122, to: 123}}
 
 dl
 scope.Defn{scopeID: I, name: N, type: T, span: S} :-
@@ -254,6 +255,7 @@ scope.Usage{definitionScopeID: 3627, defnSpan: span{from: 2483, to: 2484}, kind:
 scope.Usage{definitionScopeID: 3627, defnSpan: span{from: 2483, to: 2484}, kind: "var", name: "I", usageScopeID: 3627, usageSpan: span{from: 2545, to: 2546}}
 scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2563, to: 2564}, kind: "var", name: "I", usageScopeID: 3740, usageSpan: span{from: 2593, to: 2594}}
 scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2563, to: 2564}, kind: "var", name: "I", usageScopeID: 3740, usageSpan: span{from: 2623, to: 2624}}
+scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2572, to: 2573}, kind: "var", name: "T", usageScopeID: 3740, usageSpan: span{from: 2820, to: 2821}}
 scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2870, to: 2871}, kind: "var", name: "I", usageScopeID: 4166, usageSpan: span{from: 2900, to: 2901}}
 scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2870, to: 2871}, kind: "var", name: "I", usageScopeID: 4166, usageSpan: span{from: 2936, to: 2937}}
 scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2879, to: 2880}, kind: "var", name: "T", usageScopeID: 4166, usageSpan: span{from: 3009, to: 3010}}

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -33,6 +33,19 @@ application/datalog
 tc.Problem{desc: unboundVarInHead{name: "C", rule: "foo"}, span: span{from: 13, to: 14}}
 
 dl
+foo{id: F, span: span{from: F}, spanArr: [F]} :-
+  from{id: F} &
+  !something{pos: F} &
+  F != F.
+scope.varTerm{}
+----
+application/datalog
+scope.varTerm{kind: "var", name: "F", scopeID: 3, span: span{from: 60, to: 61}}
+scope.varTerm{kind: "var", name: "F", scopeID: 3, span: span{from: 83, to: 84}}
+scope.varTerm{kind: "var", name: "F", scopeID: 3, span: span{from: 90, to: 91}}
+scope.varTerm{kind: "var", name: "F", scopeID: 3, span: span{from: 95, to: 96}}
+
+dl
 foo{id: I, span: span{from: F, to: T}, spanArr: [F, T]} :-
   from{id: I, pos: F} &
   to{id: I, pos: T} &

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -33,7 +33,7 @@ application/datalog
 tc.Problem{desc: unboundVarInHead{name: "C", rule: "foo"}, span: span{from: 13, to: 14}}
 
 dl
-foo{id: I, span: span{from: F, to: T}} :-
+foo{id: I, span: span{from: F, to: T}, spanArr: [F, T]} :-
   from{id: I, pos: F} &
   to{id: I, pos: T} &
   !something{id: I, pos: T} &
@@ -41,8 +41,8 @@ foo{id: I, span: span{from: F, to: T}} :-
 scope.Usage{}
 ----
 application/datalog
-scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 53, to: 54}}
-scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 75, to: 76}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 70, to: 71}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 92, to: 93}}
 
 dl
 scope.Defn{scopeID: I, name: N, type: T, span: S} :-

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -50,6 +50,7 @@ application/datalog
 scope.Defn{kind: "relation", name: "foo", scopeID: global{}, span: span{from: 0, to: 3}}
 scope.Defn{kind: "var", name: "F", scopeID: 3, span: span{from: 8, to: 9}}
 scope.Defn{kind: "var", name: "F", scopeID: 3, span: span{from: 28, to: 29}}
+scope.Defn{kind: "var", name: "F", scopeID: 3, span: span{from: 42, to: 43}}
 scope.Defn{kind: "attr", name: "id", scopeID: "foo", span: span{from: 4, to: 6}}
 scope.Defn{kind: "attr", name: "span", scopeID: "foo", span: span{from: 11, to: 15}}
 scope.Defn{kind: "attr", name: "spanArr", scopeID: "foo", span: span{from: 32, to: 39}}
@@ -57,7 +58,7 @@ scope.Defn{kind: "attr", name: "spanArr", scopeID: "foo", span: span{from: 32, t
 dl
 foo{id: F, span: span{from: F}, spanArr: [F]} :-
   from{id: F} &
-  !something{pos: F} &
+  !something{pos: [F]} &
   F != F.
 scope.Var{}
 ----
@@ -65,9 +66,9 @@ application/datalog
 scope.Var{kind: "relation", name: "from", scopeID: global{}, span: span{from: 51, to: 55}}
 scope.Var{kind: "relation", name: "something", scopeID: global{}, span: span{from: 68, to: 77}}
 scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 60, to: 61}}
-scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 83, to: 84}}
-scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 90, to: 91}}
-scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 95, to: 96}}
+scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 84, to: 85}}
+scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 92, to: 93}}
+scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 97, to: 98}}
 scope.Var{kind: "attr", name: "id", scopeID: "from", span: span{from: 56, to: 58}}
 scope.Var{kind: "attr", name: "pos", scopeID: "something", span: span{from: 78, to: 81}}
 
@@ -88,6 +89,11 @@ scope.Usage{definitionScopeID: 3, defnSpan: span{from: 28, to: 29}, kind: "var",
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 35, to: 36}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 100, to: 101}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 35, to: 36}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 130, to: 131}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 35, to: 36}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 142, to: 143}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 49, to: 50}, kind: "var", name: "F", usageScopeID: 3, usageSpan: span{from: 78, to: 79}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 49, to: 50}, kind: "var", name: "F", usageScopeID: 3, usageSpan: span{from: 137, to: 138}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 52, to: 53}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 100, to: 101}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 52, to: 53}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 130, to: 131}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 52, to: 53}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 142, to: 143}}
 
 dl
 scope.Defn{scopeID: I, name: N, type: T, span: S} :-

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -30,7 +30,6 @@ foo{a: A, b: C} :- bar{a: A, b: B}.
 tc.Problem{}
 ----
 application/datalog
-tc.Problem{desc: unboundVarInHead{name: "C", rule: "foo"}, span: span{from: 13, to: 14}}
 
 dl
 foo{id: F, span: span{from: F}, spanArr: [F]} :-
@@ -42,6 +41,8 @@ scope.Var{}
 application/datalog
 scope.Var{kind: "relation", name: "from", scopeID: global{}, span: span{from: 51, to: 55}}
 scope.Var{kind: "relation", name: "something", scopeID: global{}, span: span{from: 68, to: 77}}
+scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 8, to: 9}}
+scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 28, to: 29}}
 scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 60, to: 61}}
 scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 83, to: 84}}
 scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 90, to: 91}}
@@ -57,6 +58,7 @@ foo{id: I, span: span{from: F, to: T}, spanArr: [F, T]} :-
 scope.Usage{}
 ----
 application/datalog
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 8, to: 9}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 70, to: 71}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 92, to: 93}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 122, to: 123}}
@@ -191,66 +193,104 @@ scope.Usage{definitionScopeID: global{}, defnSpan: span{from: 2855, to: 2865}, k
 scope.Usage{definitionScopeID: global{}, defnSpan: span{from: 3013, to: 3023}, kind: "relation", name: "tc.typeVar", usageScopeID: global{}, usageSpan: span{from: 2318, to: 2328}}
 scope.Usage{definitionScopeID: global{}, defnSpan: span{from: 3152, to: 3165}, kind: "relation", name: "tc.typeLambda", usageScopeID: global{}, usageSpan: span{from: 2223, to: 2236}}
 scope.Usage{definitionScopeID: global{}, defnSpan: span{from: 3347, to: 3365}, kind: "relation", name: "tc.typePlaceholder", usageScopeID: global{}, usageSpan: span{from: 2349, to: 2367}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 20, to: 21}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 20, to: 21}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 20, to: 21}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 73, to: 74}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 20, to: 21}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 125, to: 126}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 20, to: 21}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 180, to: 181}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 29, to: 30}, kind: "var", name: "N", usageScopeID: 3, usageSpan: span{from: 29, to: 30}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 29, to: 30}, kind: "var", name: "N", usageScopeID: 3, usageSpan: span{from: 82, to: 83}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 29, to: 30}, kind: "var", name: "N", usageScopeID: 3, usageSpan: span{from: 134, to: 135}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 29, to: 30}, kind: "var", name: "N", usageScopeID: 3, usageSpan: span{from: 189, to: 190}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 38, to: 39}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 38, to: 39}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 38, to: 39}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 91, to: 92}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 38, to: 39}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 143, to: 144}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 38, to: 39}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 198, to: 199}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 47, to: 48}, kind: "var", name: "S", usageScopeID: 3, usageSpan: span{from: 47, to: 48}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 47, to: 48}, kind: "var", name: "S", usageScopeID: 3, usageSpan: span{from: 104, to: 105}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 47, to: 48}, kind: "var", name: "S", usageScopeID: 3, usageSpan: span{from: 156, to: 157}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 47, to: 48}, kind: "var", name: "S", usageScopeID: 3, usageSpan: span{from: 211, to: 212}}
+scope.Usage{definitionScopeID: 315, defnSpan: span{from: 233, to: 234}, kind: "var", name: "I", usageScopeID: 315, usageSpan: span{from: 233, to: 234}}
 scope.Usage{definitionScopeID: 315, defnSpan: span{from: 233, to: 234}, kind: "var", name: "I", usageScopeID: 315, usageSpan: span{from: 297, to: 298}}
+scope.Usage{definitionScopeID: 315, defnSpan: span{from: 242, to: 243}, kind: "var", name: "N", usageScopeID: 315, usageSpan: span{from: 242, to: 243}}
 scope.Usage{definitionScopeID: 315, defnSpan: span{from: 242, to: 243}, kind: "var", name: "N", usageScopeID: 315, usageSpan: span{from: 323, to: 324}}
+scope.Usage{definitionScopeID: 315, defnSpan: span{from: 251, to: 252}, kind: "var", name: "T", usageScopeID: 315, usageSpan: span{from: 251, to: 252}}
 scope.Usage{definitionScopeID: 315, defnSpan: span{from: 251, to: 252}, kind: "var", name: "T", usageScopeID: 315, usageSpan: span{from: 332, to: 333}}
+scope.Usage{definitionScopeID: 490, defnSpan: span{from: 350, to: 351}, kind: "var", name: "I", usageScopeID: 490, usageSpan: span{from: 350, to: 351}}
 scope.Usage{definitionScopeID: 490, defnSpan: span{from: 350, to: 351}, kind: "var", name: "I", usageScopeID: 490, usageSpan: span{from: 423, to: 424}}
+scope.Usage{definitionScopeID: 490, defnSpan: span{from: 359, to: 360}, kind: "var", name: "N", usageScopeID: 490, usageSpan: span{from: 359, to: 360}}
 scope.Usage{definitionScopeID: 490, defnSpan: span{from: 359, to: 360}, kind: "var", name: "N", usageScopeID: 490, usageSpan: span{from: 504, to: 505}}
+scope.Usage{definitionScopeID: 490, defnSpan: span{from: 368, to: 369}, kind: "var", name: "T", usageScopeID: 490, usageSpan: span{from: 368, to: 369}}
 scope.Usage{definitionScopeID: 490, defnSpan: span{from: 368, to: 369}, kind: "var", name: "T", usageScopeID: 490, usageSpan: span{from: 541, to: 542}}
+scope.Usage{definitionScopeID: 490, defnSpan: span{from: 381, to: 382}, kind: "var", name: "S", usageScopeID: 490, usageSpan: span{from: 381, to: 382}}
 scope.Usage{definitionScopeID: 490, defnSpan: span{from: 381, to: 382}, kind: "var", name: "S", usageScopeID: 490, usageSpan: span{from: 513, to: 514}}
+scope.Usage{definitionScopeID: 798, defnSpan: span{from: 562, to: 563}, kind: "var", name: "I", usageScopeID: 798, usageSpan: span{from: 562, to: 563}}
 scope.Usage{definitionScopeID: 798, defnSpan: span{from: 562, to: 563}, kind: "var", name: "I", usageScopeID: 798, usageSpan: span{from: 618, to: 619}}
+scope.Usage{definitionScopeID: 798, defnSpan: span{from: 571, to: 572}, kind: "var", name: "N", usageScopeID: 798, usageSpan: span{from: 571, to: 572}}
 scope.Usage{definitionScopeID: 798, defnSpan: span{from: 571, to: 572}, kind: "var", name: "N", usageScopeID: 798, usageSpan: span{from: 671, to: 672}}
+scope.Usage{definitionScopeID: 798, defnSpan: span{from: 580, to: 581}, kind: "var", name: "T", usageScopeID: 798, usageSpan: span{from: 580, to: 581}}
 scope.Usage{definitionScopeID: 798, defnSpan: span{from: 580, to: 581}, kind: "var", name: "T", usageScopeID: 798, usageSpan: span{from: 678, to: 679}}
+scope.Usage{definitionScopeID: 798, defnSpan: span{from: 593, to: 594}, kind: "var", name: "L", usageScopeID: 798, usageSpan: span{from: 593, to: 594}}
 scope.Usage{definitionScopeID: 798, defnSpan: span{from: 593, to: 594}, kind: "var", name: "L", usageScopeID: 798, usageSpan: span{from: 691, to: 692}}
+scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 714, to: 715}, kind: "var", name: "I", usageScopeID: 1014, usageSpan: span{from: 714, to: 715}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 714, to: 715}, kind: "var", name: "I", usageScopeID: 1014, usageSpan: span{from: 753, to: 754}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 714, to: 715}, kind: "var", name: "I", usageScopeID: 1014, usageSpan: span{from: 782, to: 783}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 714, to: 715}, kind: "var", name: "I", usageScopeID: 1014, usageSpan: span{from: 820, to: 821}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 714, to: 715}, kind: "var", name: "I", usageScopeID: 1014, usageSpan: span{from: 866, to: 867}}
+scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 723, to: 724}, kind: "var", name: "N", usageScopeID: 1014, usageSpan: span{from: 723, to: 724}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 723, to: 724}, kind: "var", name: "N", usageScopeID: 1014, usageSpan: span{from: 791, to: 792}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 723, to: 724}, kind: "var", name: "N", usageScopeID: 1014, usageSpan: span{from: 913, to: 914}}
+scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 732, to: 733}, kind: "var", name: "S", usageScopeID: 1014, usageSpan: span{from: 732, to: 733}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 732, to: 733}, kind: "var", name: "S", usageScopeID: 1014, usageSpan: span{from: 800, to: 801}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 732, to: 733}, kind: "var", name: "S", usageScopeID: 1014, usageSpan: span{from: 922, to: 923}}
+scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 942, to: 943}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 942, to: 943}}
+scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 942, to: 943}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 952, to: 953}}
 scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 942, to: 943}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 973, to: 974}}
+scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 952, to: 953}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 942, to: 943}}
+scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 952, to: 953}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 952, to: 953}}
 scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 952, to: 953}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 973, to: 974}}
+scope.Usage{definitionScopeID: 1423, defnSpan: span{from: 1004, to: 1005}, kind: "var", name: "I", usageScopeID: 1423, usageSpan: span{from: 1004, to: 1005}}
 scope.Usage{definitionScopeID: 1423, defnSpan: span{from: 1004, to: 1005}, kind: "var", name: "I", usageScopeID: 1423, usageSpan: span{from: 1034, to: 1035}}
 scope.Usage{definitionScopeID: 1423, defnSpan: span{from: 1004, to: 1005}, kind: "var", name: "I", usageScopeID: 1423, usageSpan: span{from: 1067, to: 1068}}
+scope.Usage{definitionScopeID: 1423, defnSpan: span{from: 1013, to: 1014}, kind: "var", name: "S", usageScopeID: 1423, usageSpan: span{from: 1013, to: 1014}}
 scope.Usage{definitionScopeID: 1423, defnSpan: span{from: 1013, to: 1014}, kind: "var", name: "S", usageScopeID: 1423, usageSpan: span{from: 1076, to: 1077}}
+scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1102, to: 1103}, kind: "var", name: "I", usageScopeID: 1583, usageSpan: span{from: 1102, to: 1103}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1102, to: 1103}, kind: "var", name: "I", usageScopeID: 1583, usageSpan: span{from: 1199, to: 1200}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1102, to: 1103}, kind: "var", name: "I", usageScopeID: 1583, usageSpan: span{from: 1276, to: 1277}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1102, to: 1103}, kind: "var", name: "I", usageScopeID: 1583, usageSpan: span{from: 1354, to: 1355}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1102, to: 1103}, kind: "var", name: "I", usageScopeID: 1583, usageSpan: span{from: 1434, to: 1435}}
+scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1115, to: 1116}, kind: "var", name: "P", usageScopeID: 1583, usageSpan: span{from: 1115, to: 1116}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1115, to: 1116}, kind: "var", name: "P", usageScopeID: 1583, usageSpan: span{from: 1152, to: 1153}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1115, to: 1116}, kind: "var", name: "P", usageScopeID: 1583, usageSpan: span{from: 1235, to: 1236}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1115, to: 1116}, kind: "var", name: "P", usageScopeID: 1583, usageSpan: span{from: 1313, to: 1314}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1115, to: 1116}, kind: "var", name: "P", usageScopeID: 1583, usageSpan: span{from: 1391, to: 1392}}
+scope.Usage{definitionScopeID: 2159, defnSpan: span{from: 1496, to: 1497}, kind: "var", name: "L", usageScopeID: 2159, usageSpan: span{from: 1496, to: 1497}}
 scope.Usage{definitionScopeID: 2159, defnSpan: span{from: 1496, to: 1497}, kind: "var", name: "L", usageScopeID: 2159, usageSpan: span{from: 1534, to: 1535}}
 scope.Usage{definitionScopeID: 2159, defnSpan: span{from: 1496, to: 1497}, kind: "var", name: "L", usageScopeID: 2159, usageSpan: span{from: 1568, to: 1569}}
+scope.Usage{definitionScopeID: 2159, defnSpan: span{from: 1510, to: 1511}, kind: "var", name: "D", usageScopeID: 2159, usageSpan: span{from: 1510, to: 1511}}
 scope.Usage{definitionScopeID: 2159, defnSpan: span{from: 1510, to: 1511}, kind: "var", name: "D", usageScopeID: 2159, usageSpan: span{from: 1639, to: 1640}}
+scope.Usage{definitionScopeID: 2431, defnSpan: span{from: 1676, to: 1677}, kind: "var", name: "L", usageScopeID: 2431, usageSpan: span{from: 1676, to: 1677}}
 scope.Usage{definitionScopeID: 2431, defnSpan: span{from: 1676, to: 1677}, kind: "var", name: "L", usageScopeID: 2431, usageSpan: span{from: 1711, to: 1712}}
 scope.Usage{definitionScopeID: 2431, defnSpan: span{from: 1676, to: 1677}, kind: "var", name: "L", usageScopeID: 2431, usageSpan: span{from: 1745, to: 1746}}
+scope.Usage{definitionScopeID: 2431, defnSpan: span{from: 1687, to: 1688}, kind: "var", name: "I", usageScopeID: 2431, usageSpan: span{from: 1687, to: 1688}}
 scope.Usage{definitionScopeID: 2431, defnSpan: span{from: 1687, to: 1688}, kind: "var", name: "I", usageScopeID: 2431, usageSpan: span{from: 1826, to: 1827}}
+scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1848, to: 1849}, kind: "var", name: "L", usageScopeID: 2691, usageSpan: span{from: 1848, to: 1849}}
 scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1848, to: 1849}, kind: "var", name: "L", usageScopeID: 2691, usageSpan: span{from: 1890, to: 1891}}
 scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1848, to: 1849}, kind: "var", name: "L", usageScopeID: 2691, usageSpan: span{from: 1917, to: 1918}}
+scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1857, to: 1858}, kind: "var", name: "N", usageScopeID: 2691, usageSpan: span{from: 1857, to: 1858}}
 scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1857, to: 1858}, kind: "var", name: "N", usageScopeID: 2691, usageSpan: span{from: 1926, to: 1927}}
+scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1866, to: 1867}, kind: "var", name: "S", usageScopeID: 2691, usageSpan: span{from: 1866, to: 1867}}
 scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1866, to: 1867}, kind: "var", name: "S", usageScopeID: 2691, usageSpan: span{from: 1935, to: 1936}}
+scope.Usage{definitionScopeID: 2851, defnSpan: span{from: 1963, to: 1964}, kind: "var", name: "C", usageScopeID: 2851, usageSpan: span{from: 1963, to: 1964}}
 scope.Usage{definitionScopeID: 2851, defnSpan: span{from: 1963, to: 1964}, kind: "var", name: "C", usageScopeID: 2851, usageSpan: span{from: 1998, to: 1999}}
 scope.Usage{definitionScopeID: 2851, defnSpan: span{from: 1963, to: 1964}, kind: "var", name: "C", usageScopeID: 2851, usageSpan: span{from: 2024, to: 2025}}
+scope.Usage{definitionScopeID: 2851, defnSpan: span{from: 1973, to: 1974}, kind: "var", name: "I", usageScopeID: 2851, usageSpan: span{from: 1973, to: 1974}}
 scope.Usage{definitionScopeID: 2851, defnSpan: span{from: 1973, to: 1974}, kind: "var", name: "I", usageScopeID: 2851, usageSpan: span{from: 2031, to: 2032}}
+scope.Usage{definitionScopeID: 2997, defnSpan: span{from: 2060, to: 2061}, kind: "var", name: "C", usageScopeID: 2997, usageSpan: span{from: 2060, to: 2061}}
 scope.Usage{definitionScopeID: 2997, defnSpan: span{from: 2060, to: 2061}, kind: "var", name: "C", usageScopeID: 2997, usageSpan: span{from: 2096, to: 2097}}
 scope.Usage{definitionScopeID: 2997, defnSpan: span{from: 2060, to: 2061}, kind: "var", name: "C", usageScopeID: 2997, usageSpan: span{from: 2132, to: 2133}}
+scope.Usage{definitionScopeID: 2997, defnSpan: span{from: 2071, to: 2072}, kind: "var", name: "F", usageScopeID: 2997, usageSpan: span{from: 2071, to: 2072}}
 scope.Usage{definitionScopeID: 2997, defnSpan: span{from: 2071, to: 2072}, kind: "var", name: "F", usageScopeID: 2997, usageSpan: span{from: 2119, to: 2120}}
+scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2148, to: 2149}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2178, to: 2179}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2207, to: 2208}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2241, to: 2242}}
@@ -258,6 +298,7 @@ scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind:
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2302, to: 2303}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2333, to: 2334}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2372, to: 2373}}
+scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2157, to: 2158}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2187, to: 2188}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2216, to: 2217}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2250, to: 2251}}
@@ -265,22 +306,32 @@ scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind:
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2311, to: 2312}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2342, to: 2343}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2381, to: 2382}}
+scope.Usage{definitionScopeID: 3505, defnSpan: span{from: 2398, to: 2399}, kind: "var", name: "I", usageScopeID: 3505, usageSpan: span{from: 2398, to: 2399}}
 scope.Usage{definitionScopeID: 3505, defnSpan: span{from: 2398, to: 2399}, kind: "var", name: "I", usageScopeID: 3505, usageSpan: span{from: 2435, to: 2436}}
 scope.Usage{definitionScopeID: 3505, defnSpan: span{from: 2398, to: 2399}, kind: "var", name: "I", usageScopeID: 3505, usageSpan: span{from: 2466, to: 2467}}
+scope.Usage{definitionScopeID: 3627, defnSpan: span{from: 2483, to: 2484}, kind: "var", name: "I", usageScopeID: 3627, usageSpan: span{from: 2483, to: 2484}}
 scope.Usage{definitionScopeID: 3627, defnSpan: span{from: 2483, to: 2484}, kind: "var", name: "I", usageScopeID: 3627, usageSpan: span{from: 2517, to: 2518}}
 scope.Usage{definitionScopeID: 3627, defnSpan: span{from: 2483, to: 2484}, kind: "var", name: "I", usageScopeID: 3627, usageSpan: span{from: 2545, to: 2546}}
+scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2563, to: 2564}, kind: "var", name: "I", usageScopeID: 3740, usageSpan: span{from: 2563, to: 2564}}
 scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2563, to: 2564}, kind: "var", name: "I", usageScopeID: 3740, usageSpan: span{from: 2593, to: 2594}}
 scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2563, to: 2564}, kind: "var", name: "I", usageScopeID: 3740, usageSpan: span{from: 2623, to: 2624}}
+scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2572, to: 2573}, kind: "var", name: "T", usageScopeID: 3740, usageSpan: span{from: 2572, to: 2573}}
 scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2572, to: 2573}, kind: "var", name: "T", usageScopeID: 3740, usageSpan: span{from: 2820, to: 2821}}
+scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2870, to: 2871}, kind: "var", name: "I", usageScopeID: 4166, usageSpan: span{from: 2870, to: 2871}}
 scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2870, to: 2871}, kind: "var", name: "I", usageScopeID: 4166, usageSpan: span{from: 2900, to: 2901}}
 scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2870, to: 2871}, kind: "var", name: "I", usageScopeID: 4166, usageSpan: span{from: 2936, to: 2937}}
+scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2879, to: 2880}, kind: "var", name: "T", usageScopeID: 4166, usageSpan: span{from: 2879, to: 2880}}
 scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2879, to: 2880}, kind: "var", name: "T", usageScopeID: 4166, usageSpan: span{from: 3009, to: 3010}}
+scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3028, to: 3029}, kind: "var", name: "I", usageScopeID: 4388, usageSpan: span{from: 3028, to: 3029}}
 scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3028, to: 3029}, kind: "var", name: "I", usageScopeID: 4388, usageSpan: span{from: 3058, to: 3059}}
 scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3028, to: 3029}, kind: "var", name: "I", usageScopeID: 4388, usageSpan: span{from: 3094, to: 3095}}
 scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3028, to: 3029}, kind: "var", name: "I", usageScopeID: 4388, usageSpan: span{from: 3130, to: 3131}}
+scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3037, to: 3038}, kind: "var", name: "T", usageScopeID: 4388, usageSpan: span{from: 3037, to: 3038}}
 scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3037, to: 3038}, kind: "var", name: "T", usageScopeID: 4388, usageSpan: span{from: 3148, to: 3149}}
+scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3170, to: 3171}, kind: "var", name: "I", usageScopeID: 4588, usageSpan: span{from: 3170, to: 3171}}
 scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3170, to: 3171}, kind: "var", name: "I", usageScopeID: 4588, usageSpan: span{from: 3219, to: 3220}}
 scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3170, to: 3171}, kind: "var", name: "I", usageScopeID: 4588, usageSpan: span{from: 3254, to: 3255}}
+scope.Usage{definitionScopeID: 4872, defnSpan: span{from: 3370, to: 3371}, kind: "var", name: "I", usageScopeID: 4872, usageSpan: span{from: 3370, to: 3371}}
 scope.Usage{definitionScopeID: 4872, defnSpan: span{from: 3370, to: 3371}, kind: "var", name: "I", usageScopeID: 4872, usageSpan: span{from: 3408, to: 3409}}
 scope.Usage{definitionScopeID: 4872, defnSpan: span{from: 3370, to: 3371}, kind: "var", name: "I", usageScopeID: 4872, usageSpan: span{from: 3448, to: 3449}}
 scope.Usage{definitionScopeID: "scope.builtin", defnSpan: span{from: 229, to: 231}, kind: "attr", name: "id", usageScopeID: "scope.builtin", usageSpan: span{from: 69, to: 71}}

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -22,15 +22,15 @@ baz{a: A, b: B} :- foo{aa: A, bb: B}.
 tc.Problem{}
 ----
 application/datalog
-tc.Problem{desc: nonexistentAttr{attr: "aa", relation: "foo"}, nodeID: 86, span: span{from: 59, to: 61}}
-tc.Problem{desc: nonexistentAttr{attr: "bb", relation: "foo"}, nodeID: 94, span: span{from: 66, to: 68}}
+tc.Problem{desc: nonexistentAttr{attr: "aa", relation: "foo"}, span: span{from: 59, to: 61}}
+tc.Problem{desc: nonexistentAttr{attr: "bb", relation: "foo"}, span: span{from: 66, to: 68}}
 
 dl
 foo{a: A, b: C} :- bar{a: A, b: B}.
 tc.Problem{}
 ----
 application/datalog
-tc.Problem{desc: unboundVarInHead{name: "C", rule: "foo"}, nodeID: I, span: span{from: 13, to: 14}}
+tc.Problem{desc: unboundVarInHead{name: "C", rule: "foo"}, span: span{from: 13, to: 14}}
 
 dl
 foo{id: I, span: span{from: F, to: T}} :-

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -37,13 +37,16 @@ foo{id: F, span: span{from: F}, spanArr: [F]} :-
   from{id: F} &
   !something{pos: F} &
   F != F.
-scope.varTerm{}
+scope.Var{}
 ----
 application/datalog
-scope.varTerm{kind: "var", name: "F", scopeID: 3, span: span{from: 60, to: 61}}
-scope.varTerm{kind: "var", name: "F", scopeID: 3, span: span{from: 83, to: 84}}
-scope.varTerm{kind: "var", name: "F", scopeID: 3, span: span{from: 90, to: 91}}
-scope.varTerm{kind: "var", name: "F", scopeID: 3, span: span{from: 95, to: 96}}
+scope.Var{kind: "relation", name: "from", scopeID: global{}, span: span{from: 51, to: 55}}
+scope.Var{kind: "relation", name: "something", scopeID: global{}, span: span{from: 68, to: 77}}
+scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 60, to: 61}}
+scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 83, to: 84}}
+scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 90, to: 91}}
+scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 95, to: 96}}
+scope.Var{kind: "attr", name: "id", scopeID: "from", span: span{from: 56, to: 58}}
 
 dl
 foo{id: I, span: span{from: F, to: T}, spanArr: [F, T]} :-

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -32,6 +32,13 @@ tc.Problem{}
 application/datalog
 
 dl
+foo{ab: C} :- bar{bc: D}.
+scope.ruleBodyTerm{}
+----
+application/datalog
+scope.ruleBodyTerm{ruleID: 3, termOrRecord: 25}
+
+dl
 foo{id: F, span: span{from: F}, spanArr: [F]} :-
   from{id: F} &
   !something{pos: F} &
@@ -48,6 +55,7 @@ scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 83, to: 84}}
 scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 90, to: 91}}
 scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 95, to: 96}}
 scope.Var{kind: "attr", name: "id", scopeID: "from", span: span{from: 56, to: 58}}
+scope.Var{kind: "attr", name: "pos", scopeID: "something", span: span{from: 78, to: 81}}
 
 dl
 foo{id: I, span: span{from: F, to: T}, spanArr: [F, T]} :-

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -33,6 +33,16 @@ application/datalog
 tc.Problem{desc: unboundVarInHead{name: "C", rule: "foo"}, nodeID: I, span: span{from: 13, to: 14}}
 
 dl
+foo{id: I, span: span{from: F, to: T}} :-
+  from{id: I, pos: F} &
+  to{id: I, pos: T}.
+scope.Usage{}
+----
+application/datalog
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 53, to: 54}}
+scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 75, to: 76}}
+
+dl
 scope.Defn{scopeID: I, name: N, type: T, span: S} :-
   scope.builtin{id: I, name: N, type: T, location: S} |
   scope.l|||et{id: I, name: N, type: T, location: S} |

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -35,7 +35,8 @@ tc.Problem{desc: unboundVarInHead{name: "C", rule: "foo"}, nodeID: I, span: span
 dl
 foo{id: I, span: span{from: F, to: T}} :-
   from{id: I, pos: F} &
-  to{id: I, pos: T}.
+  to{id: I, pos: T} &
+  F != T.
 scope.Usage{}
 ----
 application/datalog

--- a/languageWorkbench/languages/dl/dl.dd.txt
+++ b/languageWorkbench/languages/dl/dl.dd.txt
@@ -30,6 +30,7 @@ foo{a: A, b: C} :- bar{a: A, b: B}.
 tc.Problem{}
 ----
 application/datalog
+tc.Problem{desc: unboundVarInHead{name: "C", rule: "foo"}, span: span{from: 13, to: 14}}
 
 dl
 foo{ab: C} :- bar{bc: D}.
@@ -48,8 +49,6 @@ scope.Var{}
 application/datalog
 scope.Var{kind: "relation", name: "from", scopeID: global{}, span: span{from: 51, to: 55}}
 scope.Var{kind: "relation", name: "something", scopeID: global{}, span: span{from: 68, to: 77}}
-scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 8, to: 9}}
-scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 28, to: 29}}
 scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 60, to: 61}}
 scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 83, to: 84}}
 scope.Var{kind: "var", name: "F", scopeID: 3, span: span{from: 90, to: 91}}
@@ -66,7 +65,6 @@ foo{id: I, span: span{from: F, to: T}, spanArr: [F, T]} :-
 scope.Usage{}
 ----
 application/datalog
-scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 8, to: 9}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 70, to: 71}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 92, to: 93}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 8, to: 9}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 122, to: 123}}
@@ -201,104 +199,66 @@ scope.Usage{definitionScopeID: global{}, defnSpan: span{from: 2855, to: 2865}, k
 scope.Usage{definitionScopeID: global{}, defnSpan: span{from: 3013, to: 3023}, kind: "relation", name: "tc.typeVar", usageScopeID: global{}, usageSpan: span{from: 2318, to: 2328}}
 scope.Usage{definitionScopeID: global{}, defnSpan: span{from: 3152, to: 3165}, kind: "relation", name: "tc.typeLambda", usageScopeID: global{}, usageSpan: span{from: 2223, to: 2236}}
 scope.Usage{definitionScopeID: global{}, defnSpan: span{from: 3347, to: 3365}, kind: "relation", name: "tc.typePlaceholder", usageScopeID: global{}, usageSpan: span{from: 2349, to: 2367}}
-scope.Usage{definitionScopeID: 3, defnSpan: span{from: 20, to: 21}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 20, to: 21}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 20, to: 21}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 73, to: 74}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 20, to: 21}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 125, to: 126}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 20, to: 21}, kind: "var", name: "I", usageScopeID: 3, usageSpan: span{from: 180, to: 181}}
-scope.Usage{definitionScopeID: 3, defnSpan: span{from: 29, to: 30}, kind: "var", name: "N", usageScopeID: 3, usageSpan: span{from: 29, to: 30}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 29, to: 30}, kind: "var", name: "N", usageScopeID: 3, usageSpan: span{from: 82, to: 83}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 29, to: 30}, kind: "var", name: "N", usageScopeID: 3, usageSpan: span{from: 134, to: 135}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 29, to: 30}, kind: "var", name: "N", usageScopeID: 3, usageSpan: span{from: 189, to: 190}}
-scope.Usage{definitionScopeID: 3, defnSpan: span{from: 38, to: 39}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 38, to: 39}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 38, to: 39}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 91, to: 92}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 38, to: 39}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 143, to: 144}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 38, to: 39}, kind: "var", name: "T", usageScopeID: 3, usageSpan: span{from: 198, to: 199}}
-scope.Usage{definitionScopeID: 3, defnSpan: span{from: 47, to: 48}, kind: "var", name: "S", usageScopeID: 3, usageSpan: span{from: 47, to: 48}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 47, to: 48}, kind: "var", name: "S", usageScopeID: 3, usageSpan: span{from: 104, to: 105}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 47, to: 48}, kind: "var", name: "S", usageScopeID: 3, usageSpan: span{from: 156, to: 157}}
 scope.Usage{definitionScopeID: 3, defnSpan: span{from: 47, to: 48}, kind: "var", name: "S", usageScopeID: 3, usageSpan: span{from: 211, to: 212}}
-scope.Usage{definitionScopeID: 315, defnSpan: span{from: 233, to: 234}, kind: "var", name: "I", usageScopeID: 315, usageSpan: span{from: 233, to: 234}}
 scope.Usage{definitionScopeID: 315, defnSpan: span{from: 233, to: 234}, kind: "var", name: "I", usageScopeID: 315, usageSpan: span{from: 297, to: 298}}
-scope.Usage{definitionScopeID: 315, defnSpan: span{from: 242, to: 243}, kind: "var", name: "N", usageScopeID: 315, usageSpan: span{from: 242, to: 243}}
 scope.Usage{definitionScopeID: 315, defnSpan: span{from: 242, to: 243}, kind: "var", name: "N", usageScopeID: 315, usageSpan: span{from: 323, to: 324}}
-scope.Usage{definitionScopeID: 315, defnSpan: span{from: 251, to: 252}, kind: "var", name: "T", usageScopeID: 315, usageSpan: span{from: 251, to: 252}}
 scope.Usage{definitionScopeID: 315, defnSpan: span{from: 251, to: 252}, kind: "var", name: "T", usageScopeID: 315, usageSpan: span{from: 332, to: 333}}
-scope.Usage{definitionScopeID: 490, defnSpan: span{from: 350, to: 351}, kind: "var", name: "I", usageScopeID: 490, usageSpan: span{from: 350, to: 351}}
 scope.Usage{definitionScopeID: 490, defnSpan: span{from: 350, to: 351}, kind: "var", name: "I", usageScopeID: 490, usageSpan: span{from: 423, to: 424}}
-scope.Usage{definitionScopeID: 490, defnSpan: span{from: 359, to: 360}, kind: "var", name: "N", usageScopeID: 490, usageSpan: span{from: 359, to: 360}}
 scope.Usage{definitionScopeID: 490, defnSpan: span{from: 359, to: 360}, kind: "var", name: "N", usageScopeID: 490, usageSpan: span{from: 504, to: 505}}
-scope.Usage{definitionScopeID: 490, defnSpan: span{from: 368, to: 369}, kind: "var", name: "T", usageScopeID: 490, usageSpan: span{from: 368, to: 369}}
 scope.Usage{definitionScopeID: 490, defnSpan: span{from: 368, to: 369}, kind: "var", name: "T", usageScopeID: 490, usageSpan: span{from: 541, to: 542}}
-scope.Usage{definitionScopeID: 490, defnSpan: span{from: 381, to: 382}, kind: "var", name: "S", usageScopeID: 490, usageSpan: span{from: 381, to: 382}}
 scope.Usage{definitionScopeID: 490, defnSpan: span{from: 381, to: 382}, kind: "var", name: "S", usageScopeID: 490, usageSpan: span{from: 513, to: 514}}
-scope.Usage{definitionScopeID: 798, defnSpan: span{from: 562, to: 563}, kind: "var", name: "I", usageScopeID: 798, usageSpan: span{from: 562, to: 563}}
 scope.Usage{definitionScopeID: 798, defnSpan: span{from: 562, to: 563}, kind: "var", name: "I", usageScopeID: 798, usageSpan: span{from: 618, to: 619}}
-scope.Usage{definitionScopeID: 798, defnSpan: span{from: 571, to: 572}, kind: "var", name: "N", usageScopeID: 798, usageSpan: span{from: 571, to: 572}}
 scope.Usage{definitionScopeID: 798, defnSpan: span{from: 571, to: 572}, kind: "var", name: "N", usageScopeID: 798, usageSpan: span{from: 671, to: 672}}
-scope.Usage{definitionScopeID: 798, defnSpan: span{from: 580, to: 581}, kind: "var", name: "T", usageScopeID: 798, usageSpan: span{from: 580, to: 581}}
 scope.Usage{definitionScopeID: 798, defnSpan: span{from: 580, to: 581}, kind: "var", name: "T", usageScopeID: 798, usageSpan: span{from: 678, to: 679}}
-scope.Usage{definitionScopeID: 798, defnSpan: span{from: 593, to: 594}, kind: "var", name: "L", usageScopeID: 798, usageSpan: span{from: 593, to: 594}}
 scope.Usage{definitionScopeID: 798, defnSpan: span{from: 593, to: 594}, kind: "var", name: "L", usageScopeID: 798, usageSpan: span{from: 691, to: 692}}
-scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 714, to: 715}, kind: "var", name: "I", usageScopeID: 1014, usageSpan: span{from: 714, to: 715}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 714, to: 715}, kind: "var", name: "I", usageScopeID: 1014, usageSpan: span{from: 753, to: 754}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 714, to: 715}, kind: "var", name: "I", usageScopeID: 1014, usageSpan: span{from: 782, to: 783}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 714, to: 715}, kind: "var", name: "I", usageScopeID: 1014, usageSpan: span{from: 820, to: 821}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 714, to: 715}, kind: "var", name: "I", usageScopeID: 1014, usageSpan: span{from: 866, to: 867}}
-scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 723, to: 724}, kind: "var", name: "N", usageScopeID: 1014, usageSpan: span{from: 723, to: 724}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 723, to: 724}, kind: "var", name: "N", usageScopeID: 1014, usageSpan: span{from: 791, to: 792}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 723, to: 724}, kind: "var", name: "N", usageScopeID: 1014, usageSpan: span{from: 913, to: 914}}
-scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 732, to: 733}, kind: "var", name: "S", usageScopeID: 1014, usageSpan: span{from: 732, to: 733}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 732, to: 733}, kind: "var", name: "S", usageScopeID: 1014, usageSpan: span{from: 800, to: 801}}
 scope.Usage{definitionScopeID: 1014, defnSpan: span{from: 732, to: 733}, kind: "var", name: "S", usageScopeID: 1014, usageSpan: span{from: 922, to: 923}}
-scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 942, to: 943}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 942, to: 943}}
-scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 942, to: 943}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 952, to: 953}}
 scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 942, to: 943}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 973, to: 974}}
-scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 952, to: 953}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 942, to: 943}}
-scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 952, to: 953}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 952, to: 953}}
 scope.Usage{definitionScopeID: 1347, defnSpan: span{from: 952, to: 953}, kind: "var", name: "I", usageScopeID: 1347, usageSpan: span{from: 973, to: 974}}
-scope.Usage{definitionScopeID: 1423, defnSpan: span{from: 1004, to: 1005}, kind: "var", name: "I", usageScopeID: 1423, usageSpan: span{from: 1004, to: 1005}}
 scope.Usage{definitionScopeID: 1423, defnSpan: span{from: 1004, to: 1005}, kind: "var", name: "I", usageScopeID: 1423, usageSpan: span{from: 1034, to: 1035}}
 scope.Usage{definitionScopeID: 1423, defnSpan: span{from: 1004, to: 1005}, kind: "var", name: "I", usageScopeID: 1423, usageSpan: span{from: 1067, to: 1068}}
-scope.Usage{definitionScopeID: 1423, defnSpan: span{from: 1013, to: 1014}, kind: "var", name: "S", usageScopeID: 1423, usageSpan: span{from: 1013, to: 1014}}
 scope.Usage{definitionScopeID: 1423, defnSpan: span{from: 1013, to: 1014}, kind: "var", name: "S", usageScopeID: 1423, usageSpan: span{from: 1076, to: 1077}}
-scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1102, to: 1103}, kind: "var", name: "I", usageScopeID: 1583, usageSpan: span{from: 1102, to: 1103}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1102, to: 1103}, kind: "var", name: "I", usageScopeID: 1583, usageSpan: span{from: 1199, to: 1200}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1102, to: 1103}, kind: "var", name: "I", usageScopeID: 1583, usageSpan: span{from: 1276, to: 1277}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1102, to: 1103}, kind: "var", name: "I", usageScopeID: 1583, usageSpan: span{from: 1354, to: 1355}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1102, to: 1103}, kind: "var", name: "I", usageScopeID: 1583, usageSpan: span{from: 1434, to: 1435}}
-scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1115, to: 1116}, kind: "var", name: "P", usageScopeID: 1583, usageSpan: span{from: 1115, to: 1116}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1115, to: 1116}, kind: "var", name: "P", usageScopeID: 1583, usageSpan: span{from: 1152, to: 1153}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1115, to: 1116}, kind: "var", name: "P", usageScopeID: 1583, usageSpan: span{from: 1235, to: 1236}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1115, to: 1116}, kind: "var", name: "P", usageScopeID: 1583, usageSpan: span{from: 1313, to: 1314}}
 scope.Usage{definitionScopeID: 1583, defnSpan: span{from: 1115, to: 1116}, kind: "var", name: "P", usageScopeID: 1583, usageSpan: span{from: 1391, to: 1392}}
-scope.Usage{definitionScopeID: 2159, defnSpan: span{from: 1496, to: 1497}, kind: "var", name: "L", usageScopeID: 2159, usageSpan: span{from: 1496, to: 1497}}
 scope.Usage{definitionScopeID: 2159, defnSpan: span{from: 1496, to: 1497}, kind: "var", name: "L", usageScopeID: 2159, usageSpan: span{from: 1534, to: 1535}}
 scope.Usage{definitionScopeID: 2159, defnSpan: span{from: 1496, to: 1497}, kind: "var", name: "L", usageScopeID: 2159, usageSpan: span{from: 1568, to: 1569}}
-scope.Usage{definitionScopeID: 2159, defnSpan: span{from: 1510, to: 1511}, kind: "var", name: "D", usageScopeID: 2159, usageSpan: span{from: 1510, to: 1511}}
 scope.Usage{definitionScopeID: 2159, defnSpan: span{from: 1510, to: 1511}, kind: "var", name: "D", usageScopeID: 2159, usageSpan: span{from: 1639, to: 1640}}
-scope.Usage{definitionScopeID: 2431, defnSpan: span{from: 1676, to: 1677}, kind: "var", name: "L", usageScopeID: 2431, usageSpan: span{from: 1676, to: 1677}}
 scope.Usage{definitionScopeID: 2431, defnSpan: span{from: 1676, to: 1677}, kind: "var", name: "L", usageScopeID: 2431, usageSpan: span{from: 1711, to: 1712}}
 scope.Usage{definitionScopeID: 2431, defnSpan: span{from: 1676, to: 1677}, kind: "var", name: "L", usageScopeID: 2431, usageSpan: span{from: 1745, to: 1746}}
-scope.Usage{definitionScopeID: 2431, defnSpan: span{from: 1687, to: 1688}, kind: "var", name: "I", usageScopeID: 2431, usageSpan: span{from: 1687, to: 1688}}
 scope.Usage{definitionScopeID: 2431, defnSpan: span{from: 1687, to: 1688}, kind: "var", name: "I", usageScopeID: 2431, usageSpan: span{from: 1826, to: 1827}}
-scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1848, to: 1849}, kind: "var", name: "L", usageScopeID: 2691, usageSpan: span{from: 1848, to: 1849}}
 scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1848, to: 1849}, kind: "var", name: "L", usageScopeID: 2691, usageSpan: span{from: 1890, to: 1891}}
 scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1848, to: 1849}, kind: "var", name: "L", usageScopeID: 2691, usageSpan: span{from: 1917, to: 1918}}
-scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1857, to: 1858}, kind: "var", name: "N", usageScopeID: 2691, usageSpan: span{from: 1857, to: 1858}}
 scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1857, to: 1858}, kind: "var", name: "N", usageScopeID: 2691, usageSpan: span{from: 1926, to: 1927}}
-scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1866, to: 1867}, kind: "var", name: "S", usageScopeID: 2691, usageSpan: span{from: 1866, to: 1867}}
 scope.Usage{definitionScopeID: 2691, defnSpan: span{from: 1866, to: 1867}, kind: "var", name: "S", usageScopeID: 2691, usageSpan: span{from: 1935, to: 1936}}
-scope.Usage{definitionScopeID: 2851, defnSpan: span{from: 1963, to: 1964}, kind: "var", name: "C", usageScopeID: 2851, usageSpan: span{from: 1963, to: 1964}}
 scope.Usage{definitionScopeID: 2851, defnSpan: span{from: 1963, to: 1964}, kind: "var", name: "C", usageScopeID: 2851, usageSpan: span{from: 1998, to: 1999}}
 scope.Usage{definitionScopeID: 2851, defnSpan: span{from: 1963, to: 1964}, kind: "var", name: "C", usageScopeID: 2851, usageSpan: span{from: 2024, to: 2025}}
-scope.Usage{definitionScopeID: 2851, defnSpan: span{from: 1973, to: 1974}, kind: "var", name: "I", usageScopeID: 2851, usageSpan: span{from: 1973, to: 1974}}
 scope.Usage{definitionScopeID: 2851, defnSpan: span{from: 1973, to: 1974}, kind: "var", name: "I", usageScopeID: 2851, usageSpan: span{from: 2031, to: 2032}}
-scope.Usage{definitionScopeID: 2997, defnSpan: span{from: 2060, to: 2061}, kind: "var", name: "C", usageScopeID: 2997, usageSpan: span{from: 2060, to: 2061}}
 scope.Usage{definitionScopeID: 2997, defnSpan: span{from: 2060, to: 2061}, kind: "var", name: "C", usageScopeID: 2997, usageSpan: span{from: 2096, to: 2097}}
 scope.Usage{definitionScopeID: 2997, defnSpan: span{from: 2060, to: 2061}, kind: "var", name: "C", usageScopeID: 2997, usageSpan: span{from: 2132, to: 2133}}
-scope.Usage{definitionScopeID: 2997, defnSpan: span{from: 2071, to: 2072}, kind: "var", name: "F", usageScopeID: 2997, usageSpan: span{from: 2071, to: 2072}}
 scope.Usage{definitionScopeID: 2997, defnSpan: span{from: 2071, to: 2072}, kind: "var", name: "F", usageScopeID: 2997, usageSpan: span{from: 2119, to: 2120}}
-scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2148, to: 2149}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2178, to: 2179}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2207, to: 2208}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2241, to: 2242}}
@@ -306,7 +266,6 @@ scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind:
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2302, to: 2303}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2333, to: 2334}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2148, to: 2149}, kind: "var", name: "I", usageScopeID: 3153, usageSpan: span{from: 2372, to: 2373}}
-scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2157, to: 2158}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2187, to: 2188}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2216, to: 2217}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2250, to: 2251}}
@@ -314,32 +273,22 @@ scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind:
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2311, to: 2312}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2342, to: 2343}}
 scope.Usage{definitionScopeID: 3153, defnSpan: span{from: 2157, to: 2158}, kind: "var", name: "T", usageScopeID: 3153, usageSpan: span{from: 2381, to: 2382}}
-scope.Usage{definitionScopeID: 3505, defnSpan: span{from: 2398, to: 2399}, kind: "var", name: "I", usageScopeID: 3505, usageSpan: span{from: 2398, to: 2399}}
 scope.Usage{definitionScopeID: 3505, defnSpan: span{from: 2398, to: 2399}, kind: "var", name: "I", usageScopeID: 3505, usageSpan: span{from: 2435, to: 2436}}
 scope.Usage{definitionScopeID: 3505, defnSpan: span{from: 2398, to: 2399}, kind: "var", name: "I", usageScopeID: 3505, usageSpan: span{from: 2466, to: 2467}}
-scope.Usage{definitionScopeID: 3627, defnSpan: span{from: 2483, to: 2484}, kind: "var", name: "I", usageScopeID: 3627, usageSpan: span{from: 2483, to: 2484}}
 scope.Usage{definitionScopeID: 3627, defnSpan: span{from: 2483, to: 2484}, kind: "var", name: "I", usageScopeID: 3627, usageSpan: span{from: 2517, to: 2518}}
 scope.Usage{definitionScopeID: 3627, defnSpan: span{from: 2483, to: 2484}, kind: "var", name: "I", usageScopeID: 3627, usageSpan: span{from: 2545, to: 2546}}
-scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2563, to: 2564}, kind: "var", name: "I", usageScopeID: 3740, usageSpan: span{from: 2563, to: 2564}}
 scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2563, to: 2564}, kind: "var", name: "I", usageScopeID: 3740, usageSpan: span{from: 2593, to: 2594}}
 scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2563, to: 2564}, kind: "var", name: "I", usageScopeID: 3740, usageSpan: span{from: 2623, to: 2624}}
-scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2572, to: 2573}, kind: "var", name: "T", usageScopeID: 3740, usageSpan: span{from: 2572, to: 2573}}
 scope.Usage{definitionScopeID: 3740, defnSpan: span{from: 2572, to: 2573}, kind: "var", name: "T", usageScopeID: 3740, usageSpan: span{from: 2820, to: 2821}}
-scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2870, to: 2871}, kind: "var", name: "I", usageScopeID: 4166, usageSpan: span{from: 2870, to: 2871}}
 scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2870, to: 2871}, kind: "var", name: "I", usageScopeID: 4166, usageSpan: span{from: 2900, to: 2901}}
 scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2870, to: 2871}, kind: "var", name: "I", usageScopeID: 4166, usageSpan: span{from: 2936, to: 2937}}
-scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2879, to: 2880}, kind: "var", name: "T", usageScopeID: 4166, usageSpan: span{from: 2879, to: 2880}}
 scope.Usage{definitionScopeID: 4166, defnSpan: span{from: 2879, to: 2880}, kind: "var", name: "T", usageScopeID: 4166, usageSpan: span{from: 3009, to: 3010}}
-scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3028, to: 3029}, kind: "var", name: "I", usageScopeID: 4388, usageSpan: span{from: 3028, to: 3029}}
 scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3028, to: 3029}, kind: "var", name: "I", usageScopeID: 4388, usageSpan: span{from: 3058, to: 3059}}
 scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3028, to: 3029}, kind: "var", name: "I", usageScopeID: 4388, usageSpan: span{from: 3094, to: 3095}}
 scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3028, to: 3029}, kind: "var", name: "I", usageScopeID: 4388, usageSpan: span{from: 3130, to: 3131}}
-scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3037, to: 3038}, kind: "var", name: "T", usageScopeID: 4388, usageSpan: span{from: 3037, to: 3038}}
 scope.Usage{definitionScopeID: 4388, defnSpan: span{from: 3037, to: 3038}, kind: "var", name: "T", usageScopeID: 4388, usageSpan: span{from: 3148, to: 3149}}
-scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3170, to: 3171}, kind: "var", name: "I", usageScopeID: 4588, usageSpan: span{from: 3170, to: 3171}}
 scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3170, to: 3171}, kind: "var", name: "I", usageScopeID: 4588, usageSpan: span{from: 3219, to: 3220}}
 scope.Usage{definitionScopeID: 4588, defnSpan: span{from: 3170, to: 3171}, kind: "var", name: "I", usageScopeID: 4588, usageSpan: span{from: 3254, to: 3255}}
-scope.Usage{definitionScopeID: 4872, defnSpan: span{from: 3370, to: 3371}, kind: "var", name: "I", usageScopeID: 4872, usageSpan: span{from: 3370, to: 3371}}
 scope.Usage{definitionScopeID: 4872, defnSpan: span{from: 3370, to: 3371}, kind: "var", name: "I", usageScopeID: 4872, usageSpan: span{from: 3408, to: 3409}}
 scope.Usage{definitionScopeID: 4872, defnSpan: span{from: 3370, to: 3371}, kind: "var", name: "I", usageScopeID: 4872, usageSpan: span{from: 3448, to: 3449}}
 scope.Usage{definitionScopeID: "scope.builtin", defnSpan: span{from: 229, to: 231}, kind: "attr", name: "id", usageScopeID: "scope.builtin", usageSpan: span{from: 69, to: 71}}

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -78,18 +78,14 @@ scope.placeholderAttr{scopeID: Relation, span: S, kind: "attr"} :-
 # maybe by using scope.parent instead of explicitly joining down
 
 # TODO: var in head that's unbound
-tc.Problem{desc: D, nodeID: I, span: S} :-
-  tc.nonexistentAttr{desc: D, nodeID: I, span: S} |
-  tc.unboundVarInHead{desc: D, nodeID: I, span: S}.
-tc.nonexistentAttr{
-  desc: nonexistentAttr{relation: Relation, attr: N},
-  nodeID: I,
-  span: S
-} :-
+tc.Problem{desc: D, span: S} :-
+  tc.nonexistentAttr{desc: D, span: S} |
+  tc.unboundVarInHead{desc: D, span: S}.
+tc.nonexistentAttr{desc: nonexistentAttr{relation: Relation, attr: N}, span: S} :-
   scope.defnRule{name: Relation} &
-  scope.varAttr{scopeID: Relation, nodeID: I, name: N, span: S} &
+  scope.varAttr{scopeID: Relation, name: N, span: S} &
   !tc.ruleAttr{rule: Relation, attr: N}.
-tc.unboundVarInHead{desc: unboundVarInHead{rule: R, name: N}, nodeID: I, span: S} :-
+tc.unboundVarInHead{desc: unboundVarInHead{rule: R, name: N}, span: S} :-
   scope.defnVar{scopeID: RuleID, span: S, name: N} &
   scope.rule{scopeID: RuleID, name: R} &
   !scope.varTerm{scopeID: RuleID, name: N}.

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -98,10 +98,12 @@ scope.termOrRecordVar{term: TermOrRecord, name: N, span: S} :-
   scope.termVar{term: TermOrRecord, name: N, span: S}.
 scope.termVar{term: Term, name: N, span: S} :-
   ast.term{id: Term} &
-  ast.var{parentID: Term, text: N, span: S} |
+  ast.var{parentID: Term, text: N, span: S}
+  |
   ast.term{id: Term} &
   ast.record{id: Record, parentID: Term} &
-  scope.recordVar{record: Record, name: N, span: S} |
+  scope.recordVar{record: Record, name: N, span: S}
+  |
   ast.term{id: Term} &
   ast.array{id: Array, parentID: Term} &
   ast.term{id: Term, parentID: Array} &

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -74,8 +74,21 @@ scope.placeholderAttr{scopeID: Relation, span: S, kind: "attr"} :-
   ast.keyValue{id: KV, parentID: Rec} &
   ast.placeholder{parentID: KV, span: S}.
 
-# TODO: make autocompletion work inside of negations
-# maybe by using scope.parent instead of explicitly joining down
+scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} :-
+  ast.rule{id: Rule} &
+  ast.disjunct{id: Disjunct, parentID: Rule} &
+  ast.conjunct{id: Conjunct, parentID: Disjunct}.
+# it's kind of an issue that some of them are records
+# and some of them are terms
+scope.ruleTerm{ruleID: Rule, termID: Term} :-
+  scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
+  ast.record{id: Term, parentID: Conjunct} |
+  scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
+  ast.negation{id: Negation, parentID: Conjunct} &
+  ast.record{id: Term, parentID: Negation} |
+  scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
+  ast.binExpr{id: BinExpr, parentID: Conjunct} &
+  ast.term{id: Term, parentID: BinExpr}.
 
 # TODO: var in head that's unbound
 tc.Problem{desc: D, span: S} :-

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -100,8 +100,8 @@ scope.termVar{term: Term, name: N, span: S} :-
   |
   ast.term{id: Term} &
   ast.array{id: Array, parentID: Term} &
-  ast.term{id: Term, parentID: Array} &
-  scope.termVar{term: Term, name: N, span: S}.
+  ast.term{id: ArrItemTerm, parentID: Array} &
+  scope.termVar{term: ArrItemTerm, name: N, span: S}.
 scope.recordVar{record: Record, name: N, span: S} :-
   ast.record{id: Record} &
   ast.keyValue{id: KeyValue, parentID: Record} &

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -34,14 +34,10 @@ scope.varRuleInvocation{scopeID: global{}, name: N, span: S, kind: "relation"} :
   ast.record{id: RecordID, parentID: ConjunctID} &
   ast.ident{parentID: RecordID, text: N, span: S}.
 # TODO: bin exprs
-scope.varTerm{scopeID: RuleID, name: N, span: S, kind: "var"} :-
-  ast.rule{id: RuleID} &
-  ast.disjunct{id: DisjunctID, parentID: RuleID} &
-  ast.conjunct{id: ConjunctID, parentID: DisjunctID} &
-  ast.record{id: RecordID, parentID: ConjunctID} &
-  ast.keyValue{id: KeyValueID, parentID: RecordID} &
-  ast.term{id: ValueTermID, parentID: KeyValueID} &
-  ast.var{parentID: ValueTermID, text: N, span: S}.
+scope.varTerm{scopeID: Rule, name: N, span: S, kind: "var"} :-
+  scope.ruleTerm{ruleID: Rule, termOrRecord: TermOrRecord} &
+  scope.termOrRecordVar{term: TermOrRecord, name: N, span: S}.
+# TODO: make this use ruleTerm and termVar as well
 scope.varAttr{scopeID: Relation, nodeID: I, name: N, span: S, kind: "attr"} :-
   ast.conjunct{id: Conjunct} &
   ast.record{id: Rec, parentID: Conjunct} &
@@ -83,15 +79,15 @@ scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} :-
   ast.conjunct{id: Conjunct, parentID: Disjunct}.
 # it's kind of an issue that some of them are records
 # and some of them are terms
-scope.ruleTerm{ruleID: Rule, termID: Term} :-
+scope.ruleTerm{ruleID: Rule, termOrRecord: TermOrRecord} :-
   scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
-  ast.record{id: Term, parentID: Conjunct} |
+  ast.record{id: TermOrRecord, parentID: Conjunct} |
   scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
   ast.negation{id: Negation, parentID: Conjunct} &
-  ast.record{id: Term, parentID: Negation} |
+  ast.record{id: TermOrRecord, parentID: Negation} |
   scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
   ast.binExpr{id: BinExpr, parentID: Conjunct} &
-  ast.term{id: Term, parentID: BinExpr}.
+  ast.term{id: TermOrRecord, parentID: BinExpr}.
 
 scope.termOrRecordVar{term: TermOrRecord, name: N, span: S} :-
   scope.recordVar{record: TermOrRecord, name: N, span: S} |

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -49,6 +49,7 @@ scope.varAttr{scopeID: Relation, nodeID: I, name: N, span: S, kind: "attr"} :-
   ast.keyValue{id: KV, parentID: Rec} &
   ast.ident{id: I, parentID: KV, text: N, span: S}.
 
+# TODO: get placeholders in nested terms
 scope.Placeholder{scopeID: I, span: S, kind: K} :-
   scope.placeholderVar{scopeID: I, span: S, kind: K} |
   scope.placeholderRule{scopeID: I, span: S, kind: K} |
@@ -89,6 +90,10 @@ scope.ruleTerm{ruleID: Rule, termID: Term} :-
   scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
   ast.binExpr{id: BinExpr, parentID: Conjunct} &
   ast.term{id: Term, parentID: BinExpr}.
+scope.termOrRecordVar{} :-
+  XXX{}.
+scope.termVar{} :-
+  XXXX{}.
 
 # TODO: var in head that's unbound
 tc.Problem{desc: D, span: S} :-

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -29,11 +29,9 @@ scope.Var{scopeID: I, name: N, span: S, kind: K} :-
   scope.varAttr{scopeID: I, name: N, span: S, kind: K}.
 scope.varRuleInvocation{scopeID: global{}, name: N, span: S, kind: "relation"} :-
   ast.rule{id: RuleID} &
-  ast.disjunct{id: DisjunctID, parentID: RuleID} &
-  ast.conjunct{id: ConjunctID, parentID: DisjunctID} &
+  scope.ruleTerm{ruleID: RuleID, termOrRecord: RecordID} &
   ast.record{id: RecordID, parentID: ConjunctID} &
   ast.ident{parentID: RecordID, text: N, span: S}.
-# TODO: bin exprs
 scope.varTerm{scopeID: Rule, name: N, span: S, kind: "var"} :-
   scope.ruleTerm{ruleID: Rule, termOrRecord: TermOrRecord} &
   scope.termOrRecordVar{term: TermOrRecord, name: N, span: S}.

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -75,6 +75,8 @@ scope.placeholderAttr{scopeID: Relation, span: S, kind: "attr"} :-
   ast.keyValue{id: KV, parentID: Rec} &
   ast.placeholder{parentID: KV, span: S}.
 
+# === rules for traversing into nested terms ===
+
 scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} :-
   ast.rule{id: Rule} &
   ast.disjunct{id: Disjunct, parentID: Rule} &
@@ -90,12 +92,28 @@ scope.ruleTerm{ruleID: Rule, termID: Term} :-
   scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
   ast.binExpr{id: BinExpr, parentID: Conjunct} &
   ast.term{id: Term, parentID: BinExpr}.
-scope.termOrRecordVar{} :-
-  XXX{}.
-scope.termVar{} :-
-  XXXX{}.
 
-# TODO: var in head that's unbound
+scope.termOrRecordVar{term: TermOrRecord, name: N, span: S} :-
+  scope.recordVar{record: TermOrRecord, name: N, span: S} |
+  scope.termVar{term: TermOrRecord, name: N, span: S}.
+scope.termVar{term: Term, name: N, span: S} :-
+  ast.term{id: Term} &
+  ast.var{parentID: Term, text: N, span: S} |
+  ast.term{id: Term} &
+  ast.record{id: Record, parentID: Term} &
+  scope.recordVar{record: Record, name: N, span: S} |
+  ast.term{id: Term} &
+  ast.array{id: Array, parentID: Term} &
+  ast.term{id: Term, parentID: Array} &
+  scope.termVar{term: Term, name: N, span: S}.
+scope.recordVar{record: Record, name: N, span: S} :-
+  ast.record{id: Record} &
+  ast.keyValue{id: KeyValue, parentID: Record} &
+  ast.term{id: ValueTerm, parentID: KeyValue} &
+  scope.termVar{term: ValueTerm, name: N, span: S}.
+
+# === problems ===
+
 tc.Problem{desc: D, span: S} :-
   tc.nonexistentAttr{desc: D, span: S} |
   tc.unboundVarInHead{desc: D, span: S}.

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -41,8 +41,8 @@ scope.varTerm{scopeID: Rule, name: N, span: S, kind: "var"} :-
   scope.termOrRecordVar{term: TermOrRecord, name: N, span: S}.
 # TODO: recurse into nested records?
 scope.varAttr{scopeID: Relation, nodeID: I, name: N, span: S, kind: "attr"} :-
-  ast.conjunct{id: Conjunct} &
-  ast.record{id: Rec, parentID: Conjunct} &
+  scope.ruleBodyTerm{termOrRecord: Rec} &
+  ast.record{id: Rec} &
   ast.ident{parentID: Rec, text: Relation} &
   ast.keyValue{id: KV, parentID: Rec} &
   ast.ident{id: I, parentID: KV, text: N, span: S}.

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -29,7 +29,7 @@ scope.Var{scopeID: I, name: N, span: S, kind: K} :-
   scope.varAttr{scopeID: I, name: N, span: S, kind: K}.
 scope.varRuleInvocation{scopeID: global{}, name: N, span: S, kind: "relation"} :-
   ast.rule{id: RuleID} &
-  scope.ruleTerm{ruleID: RuleID, termOrRecord: RecordID} &
+  scope.ruleBodyTerm{ruleID: RuleID, termOrRecord: RecordID} &
   ast.record{id: RecordID, parentID: ConjunctID} &
   ast.ident{parentID: RecordID, text: N, span: S}.
 scope.varTerm{scopeID: Rule, name: N, span: S, kind: "var"} :-
@@ -37,9 +37,9 @@ scope.varTerm{scopeID: Rule, name: N, span: S, kind: "var"} :-
   ast.record{id: Head, parentID: Rule} &
   scope.recordVar{record: Head, name: N, span: S}
   |
-  scope.ruleTerm{ruleID: Rule, termOrRecord: TermOrRecord} &
+  scope.ruleBodyTerm{ruleID: Rule, termOrRecord: TermOrRecord} &
   scope.termOrRecordVar{term: TermOrRecord, name: N, span: S}.
-# TODO: make this use ruleTerm and termVar as well
+# TODO: recurse into nested records?
 scope.varAttr{scopeID: Relation, nodeID: I, name: N, span: S, kind: "attr"} :-
   ast.conjunct{id: Conjunct} &
   ast.record{id: Rec, parentID: Conjunct} &
@@ -81,7 +81,7 @@ scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} :-
   ast.conjunct{id: Conjunct, parentID: Disjunct}.
 # it's kind of an issue that some of them are records
 # and some of them are terms
-scope.ruleTerm{ruleID: Rule, termOrRecord: TermOrRecord} :-
+scope.ruleBodyTerm{ruleID: Rule, termOrRecord: TermOrRecord} :-
   scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
   ast.record{id: TermOrRecord, parentID: Conjunct}
   |

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -81,10 +81,12 @@ scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} :-
 # and some of them are terms
 scope.ruleTerm{ruleID: Rule, termOrRecord: TermOrRecord} :-
   scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
-  ast.record{id: TermOrRecord, parentID: Conjunct} |
+  ast.record{id: TermOrRecord, parentID: Conjunct}
+  |
   scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
   ast.negation{id: Negation, parentID: Conjunct} &
-  ast.record{id: TermOrRecord, parentID: Negation} |
+  ast.record{id: TermOrRecord, parentID: Negation}
+  |
   scope.ruleConjunct{ruleID: Rule, conjunct: Conjunct} &
   ast.binExpr{id: BinExpr, parentID: Conjunct} &
   ast.term{id: TermOrRecord, parentID: BinExpr}.

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -33,6 +33,10 @@ scope.varRuleInvocation{scopeID: global{}, name: N, span: S, kind: "relation"} :
   ast.record{id: RecordID, parentID: ConjunctID} &
   ast.ident{parentID: RecordID, text: N, span: S}.
 scope.varTerm{scopeID: Rule, name: N, span: S, kind: "var"} :-
+  ast.rule{id: Rule} &
+  ast.record{id: Head, parentID: Rule} &
+  scope.recordVar{record: Head, name: N, span: S}
+  |
   scope.ruleTerm{ruleID: Rule, termOrRecord: TermOrRecord} &
   scope.termOrRecordVar{term: TermOrRecord, name: N, span: S}.
 # TODO: make this use ruleTerm and termVar as well

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -33,10 +33,6 @@ scope.varRuleInvocation{scopeID: global{}, name: N, span: S, kind: "relation"} :
   ast.record{id: RecordID, parentID: ConjunctID} &
   ast.ident{parentID: RecordID, text: N, span: S}.
 scope.varTerm{scopeID: Rule, name: N, span: S, kind: "var"} :-
-  ast.rule{id: Rule} &
-  ast.record{id: Head, parentID: Rule} &
-  scope.recordVar{record: Head, name: N, span: S}
-  |
   scope.ruleBodyTerm{ruleID: Rule, termOrRecord: TermOrRecord} &
   scope.termOrRecordVar{term: TermOrRecord, name: N, span: S}.
 # TODO: recurse into nested records?

--- a/languageWorkbench/languages/dl/dl.dl
+++ b/languageWorkbench/languages/dl/dl.dl
@@ -14,9 +14,7 @@ scope.defnRule{scopeID: global{}, span: S, name: N, kind: "relation"} :-
 scope.defnVar{scopeID: RuleID, name: N, span: S, kind: "var"} :-
   ast.rule{id: RuleID} &
   ast.record{id: RecordID, parentID: RuleID} &
-  ast.keyValue{id: KeyValueID, parentID: RecordID} &
-  ast.term{id: ValueTermID, parentID: KeyValueID} &
-  ast.var{span: S, text: N, parentID: ValueTermID}.
+  scope.recordVar{record: RecordID, name: N, span: S}.
 scope.defnTable{scopeID: global{}, name: N, span: S, kind: "relation"} :-
   ast.tableDecl{id: DeclID} &
   ast.ident{parentID: DeclID, span: S, text: N}.

--- a/languageWorkbench/languages/fp/fp.dd.txt
+++ b/languageWorkbench/languages/fp/fp.dd.txt
@@ -67,21 +67,21 @@ plus2("hello world")
 tc.Problem{}
 ----
 application/datalog
-tc.Problem{desc: argTypeMismatch{expected: "int", got: "string"}, nodeID: 14, span: span{from: 6, to: 19}}
+tc.Problem{desc: argTypeMismatch{expected: "int", got: "string"}, span: span{from: 6, to: 19}}
 
 fp
 (x: string): int => plus2(x)
 tc.Problem{}
 ----
 application/datalog
-tc.Problem{desc: argTypeMismatch{expected: "int", got: "string"}, nodeID: 45, span: span{from: 26, to: 27}}
+tc.Problem{desc: argTypeMismatch{expected: "int", got: "string"}, span: span{from: 26, to: 27}}
 
 fp
 let x = 2 in y
 tc.Problem{}
 ----
 application/datalog
-tc.Problem{desc: undefinedVar{name: "y"}, nodeID: 15, span: span{from: 13, to: 14}}
+tc.Problem{desc: undefinedVar{name: "y"}, span: span{from: 13, to: 14}}
 
 fp
 let x = 2 in x

--- a/languageWorkbench/languages/fp/fp.dl
+++ b/languageWorkbench/languages/fp/fp.dl
@@ -119,11 +119,11 @@ tc.typePlaceholder{id: I, type: "unknown"} :-
 
 # === problems ===
 
-tc.Problem{desc: D, nodeID: I, span: S} :-
-  tc.wrongArgType{desc: D, nodeID: I, span: S} |
-  tc.undefinedVar{desc: D, nodeID: I, span: S}.
+tc.Problem{desc: D, span: S} :-
+  tc.wrongArgType{desc: D, span: S} |
+  tc.undefinedVar{desc: D, span: S}.
 # TODO: DRY this up with tc.typeFC
-tc.wrongArgType{desc: argTypeMismatch{expected: RequiredArgType, got: ArgType}, nodeID: AID, span: S} :-
+tc.wrongArgType{desc: argTypeMismatch{expected: RequiredArgType, got: ArgType}, span: S} :-
   ast.funcCall{parentID: I, id: FC} &
   ast.funcCallArg{callID: FC, argID: AID} &
   ast.funcCallFunc{callID: FC, funcID: FID} &
@@ -132,7 +132,7 @@ tc.wrongArgType{desc: argTypeMismatch{expected: RequiredArgType, got: ArgType}, 
   scope.Item{scopeID: FID, name: N, type: tapp{from: RequiredArgType, to: T}} &
   tc.Type{id: AID, type: ArgType} &
   RequiredArgType != ArgType.
-tc.undefinedVar{desc: undefinedVar{name: N}, nodeID: I, span: S} :-
+tc.undefinedVar{desc: undefinedVar{name: N}, span: S} :-
   ast.expr{id: I} &
   ast.varExpr{id: Var, parentID: I, span: S, text: N} &
   !scope.Item{scopeID: I, name: N}.

--- a/languageWorkbench/languages/grammar/grammar.dd.txt
+++ b/languageWorkbench/languages/grammar/grammar.dd.txt
@@ -12,7 +12,7 @@ foo :- baz.
 tc.Problem{}
 ----
 application/datalog
-tc.Problem{desc: undefinedRule{name: "baz"}, nodeID: I, span: span{from: 7, to: 10}}
+tc.Problem{desc: undefinedRule{name: "baz"}, span: span{from: 7, to: 10}}
 
 grammar
 a :- (^'"' | ['\', '"']).

--- a/languageWorkbench/languages/grammar/grammar.dl
+++ b/languageWorkbench/languages/grammar/grammar.dl
@@ -10,9 +10,9 @@ scope.Var{scopeID: global{}, name: N, span: S, kind: "rule"} :-
 scope.Placeholder{scopeID: global{}, span: S, kind: "rule"} :-
   ast.placeholder{span: S}.
 
-tc.Problem{desc: D, nodeID: I, span: S} :-
-  tc.undefinedRule{desc: D, nodeID: I, span: S}.
-tc.undefinedRule{desc: undefinedRule{name: N}, nodeID: I, span: S} :-
+tc.Problem{desc: D, span: S} :-
+  tc.undefinedRule{desc: D, span: S}.
+tc.undefinedRule{desc: undefinedRule{name: N}, span: S} :-
   scope.Var{name: N, span: S} &
   !scope.Defn{name: N}.
 

--- a/uiCommon/explorer/vizArea.tsx
+++ b/uiCommon/explorer/vizArea.tsx
@@ -47,6 +47,7 @@ function IndividualViz(props: {
             interp={props.interp}
             spec={props.spec}
             setHighlightedTerm={props.setHighlightedTerm}
+            id={props.name}
           />
         ) : (
           <pre>viz {props.spec.relation} not found</pre>

--- a/uiCommon/visualizations/examples/graphviz.dl
+++ b/uiCommon/visualizations/examples/graphviz.dl
@@ -1,0 +1,7 @@
+internal.visualization{
+  name: "Scope Graph",
+  spec: graphviz{
+    nodes: "node{id: ID}",
+    edges: "edge{from: From, to: To, label: Label}"
+  }
+}.

--- a/uiCommon/visualizations/graphviz.tsx
+++ b/uiCommon/visualizations/graphviz.tsx
@@ -6,18 +6,6 @@ import { Graphviz } from "graphviz-react";
 import { prettyPrintGraph, Node, Edge } from "../../util/graphviz";
 import { ppt } from "../../core/pretty";
 
-/*
-Example:
-
-internal.visualization{
-  name: "Scope Graph",
-  spec: graphviz{
-    nodes: "node{id: ID}",
-    edges: "edge{from: From, to: To, label: Label}"
-  }
-}.
-*/
-
 export const graphviz: VizTypeSpec = {
   name: "Graphviz",
   description: "visualize directed graphs",

--- a/uiCommon/visualizations/tree.tsx
+++ b/uiCommon/visualizations/tree.tsx
@@ -1,10 +1,15 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { Bool, Rec, StringLit, Term } from "../../core/types";
 import { VizTypeSpec } from "./typeSpec";
 import { AbstractInterpreter } from "../../core/abstractInterpreter";
-import { emptyCollapseState, TreeView } from "../generic/treeView";
+import {
+  emptyCollapseState,
+  TreeCollapseState,
+  TreeView,
+} from "../generic/treeView";
 import { BareTerm } from "../dl/replViews";
 import { treeFromRecords } from "../generic/treeFromRecords";
+import { useJSONLocalStorage } from "../generic/hooks";
 
 export const tree: VizTypeSpec = {
   name: "Tree",
@@ -14,10 +19,15 @@ export const tree: VizTypeSpec = {
 
 function TreeViz(props: {
   interp: AbstractInterpreter;
+  id: string;
   spec: Rec;
   setHighlightedTerm: (t: Term | null) => void;
 }) {
-  const [collapseState, setCollapseState] = useState(emptyCollapseState);
+  const [collapseState, setCollapseState] =
+    useJSONLocalStorage<TreeCollapseState>(
+      `tree-viz-${props.id}`,
+      emptyCollapseState
+    );
   try {
     const nodesQuery = (props.spec.attrs.nodes as StringLit).val;
     const sortChildren = (props.spec.attrs.sortChildren as Bool)?.val;

--- a/uiCommon/visualizations/typeSpec.ts
+++ b/uiCommon/visualizations/typeSpec.ts
@@ -7,6 +7,7 @@ export type VizTypeSpec = {
   component: (props: {
     interp: AbstractInterpreter;
     spec: Rec;
+    id: string; // uniquely identify this visualization instance
     setHighlightedTerm: (t: Term | null) => void;
   }) => React.ReactElement;
 };


### PR DESCRIPTION
Recurse into nested terms to get all variables 
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/7341/167286404-5adf8829-394d-4e60-ba9e-ef37ef553818.png">

Still not accounting for inner variables… #159