### PR TITLE
fix unification against arrays and dicts

### DIFF
--- a/core/ddTests.ts
+++ b/core/ddTests.ts
@@ -67,6 +67,7 @@ function coreTests(
     "literals",
     "negation",
     "aggregation",
+    "paths",
   ].map((name) => ({
     name,
     test() {

--- a/core/evalBuiltin.ts
+++ b/core/evalBuiltin.ts
@@ -6,7 +6,10 @@ export function evalBuiltin(term: Rec, scope: Bindings) {
   const builtin = BUILTINS[term.relation];
   const substituted = substitute(term, scope) as Rec;
   const records = builtin(substituted);
-  // console.log({ substituted: ppt(substituted), res: res.map(ppr) });
+  // console.log("evalBuiltin", {
+  //   substituted: ppt(substituted),
+  //   res: records.map(ppt),
+  // });
   const results = records.map(
     (rec): Res => ({
       term: rec,
@@ -14,6 +17,6 @@ export function evalBuiltin(term: Rec, scope: Bindings) {
       trace: { type: "BaseFactTrace" }, // TODO: BuiltinTrace?
     })
   );
-  // console.log(results.map(ppr));
+  // console.log("evalBuiltin", "results", results);
   return results;
 }

--- a/core/testdata/paths.dd.txt
+++ b/core/testdata/paths.dd.txt
@@ -1,0 +1,21 @@
+edge{from: 1, to: 2}.
+edge{from: 2, to: 3}.
+edge{from: 3, to: 4}.
+path{from: A, to: B, path: P} :-
+  oneEdge{from: A, to: B, path: P} |
+  multipleEdges{from: A, to: B, path: P}.
+oneEdge{from: A, to: B, path: [A, B]} :-
+  edge{from: A, to: B}.
+multipleEdges{from: A, to: B, path: P} :-
+  edge{from: A, to: C} &
+  path{from: C, to: B, path: Rest} &
+  array.prepend{value: A, in: Rest, out: P}.
+path{}?
+----
+application/datalog
+path{from: 1, path: [1,2,3,4], to: 4}.
+path{from: 1, path: [1,2,3], to: 3}.
+path{from: 1, path: [1,2], to: 2}.
+path{from: 2, path: [2,3,4], to: 4}.
+path{from: 2, path: [2,3], to: 3}.
+path{from: 3, path: [3,4], to: 4}.

--- a/core/unify.ts
+++ b/core/unify.ts
@@ -86,7 +86,8 @@ function doUnify(prior: Bindings, left: Term, right: Term): Bindings | null {
             accum = { ...accum, ...res };
           }
           return accum;
-        // TODO: add Var case?
+        case "Var":
+          return { [right.name]: left };
         default:
           return null;
       }
@@ -109,6 +110,8 @@ function doUnify(prior: Bindings, left: Term, right: Term): Bindings | null {
           }
           return accum;
         }
+        case "Var":
+          return { [right.name]: left };
         default:
           return null;
       }


### PR DESCRIPTION
paths example that actually finds the paths:
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/7341/182220004-71d06da1-ce9d-4ebd-a41f-e447325413de.png">
