### PR TITLE
KVChat: use message ids instead of seq nos

### DIFF
--- a/apps/actors/main.tsx
+++ b/apps/actors/main.tsx
@@ -88,6 +88,25 @@ function MultiClient<St extends Json, Msg extends Json>(props: {
 
   return (
     <>
+      <button
+        onClick={() => {
+          props.dispatch({ type: "AllocateClientID" });
+          // TODO: DRY this up with other place client id is constructed
+          const clientID = `client${props.systemInstance.nextClientID}`;
+          props.dispatch({
+            type: "UpdateTrace",
+            action: {
+              type: "SpawnClient",
+              id: props.systemInstance.nextClientID.toString(),
+              initialUserState: props.systemInstance.system.initialUserState,
+              initialClientState:
+                props.systemInstance.system.initialClientState(clientID),
+            },
+          });
+        }}
+      >
+        Add Client
+      </button>
       <table style={{ borderCollapse: "collapse" }}>
         <thead>
           <tr>
@@ -125,6 +144,7 @@ function MultiClient<St extends Json, Msg extends Json>(props: {
                   style={{
                     borderLeft: "1px solid lightgrey",
                     borderRight: "1px solid lightgrey",
+                    verticalAlign: "top",
                   }}
                 >
                   {clientState ? (
@@ -139,25 +159,6 @@ function MultiClient<St extends Json, Msg extends Json>(props: {
           </tr>
         </tbody>
       </table>
-      <button
-        onClick={() => {
-          props.dispatch({ type: "AllocateClientID" });
-          // TODO: DRY this up with other place client id is constructed
-          const clientID = `client${props.systemInstance.nextClientID}`;
-          props.dispatch({
-            type: "UpdateTrace",
-            action: {
-              type: "SpawnClient",
-              id: props.systemInstance.nextClientID.toString(),
-              initialUserState: props.systemInstance.system.initialUserState,
-              initialClientState:
-                props.systemInstance.system.initialClientState(clientID),
-            },
-          });
-        }}
-      >
-        Add Client
-      </button>
     </>
   );
 }

--- a/apps/actors/patterns.dl
+++ b/apps/actors/patterns.dl
@@ -62,3 +62,22 @@ concurrentRequests{
   hop{from: tick{place: Client2, time: TC2}, to: tick{time: TS2, place: "server"}, message: M2} &
   TC1 < TC2 &
   TC2 < TS1.
+
+kvSync.aborts{
+  fromActorID: ClientActor,
+  toActorID: ServerActor,
+  request: Req,
+  txnID: TxnID,
+  sendTick: SendTick,
+  respondTick: RespondTick,
+  handleResponseTick: HandleResponseTick
+} :-
+  requestResponse{
+    fromActorID: ClientActor,
+    toActorID: ServerActor,
+    request: Req,
+    response: MutationResponse{txnID: TxnID, response: Abort{}},
+    sendTick: SendTick,
+    respondTick: RespondTick,
+    handleResponseTick: HandleResponseTick
+  }.

--- a/apps/actors/systems/kvSync/client.ts
+++ b/apps/actors/systems/kvSync/client.ts
@@ -133,8 +133,10 @@ function runMutationOnClient(
 ): [ClientState, MutationRequest | null] {
   const randNum = randStep(state.randSeed);
   const txnID = randNum.toString();
-  const [data1, outcome, trace] = runMutation(
+  const initialInterpState = { randSeed: randStep(randNum) };
+  const [data1, newInterpState, outcome, trace] = runMutation(
     state.data,
+    initialInterpState,
     txnID,
     state.mutationDefns[invocation.name],
     invocation.args,
@@ -147,7 +149,7 @@ function runMutationOnClient(
   }
   const state2: ClientState = {
     ...state1,
-    randSeed: randNum,
+    randSeed: newInterpState.randSeed,
     transactions: {
       ...state1.transactions,
       [txnID]: { invocation: invocation, state: { type: "Pending" } },
@@ -156,6 +158,7 @@ function runMutationOnClient(
   const req: MutationRequest = {
     type: "MutationRequest",
     txnID,
+    interpState: initialInterpState,
     invocation: invocation,
     trace: trace,
   };

--- a/apps/actors/systems/kvSync/examples/bank.dd.txt
+++ b/apps/actors/systems/kvSync/examples/bank.dd.txt
@@ -6,14 +6,14 @@ runMutation{from: "0", name: "move", args: ["foo", "bar", 5]}.
 ----
 application/datalog
 hop{from: tick{place: "user0", time: 3}, message: RunMutation{invocation: {args: ["foo",10], name: "deposit"}}, to: tick{place: "client0", time: 5}}.
-hop{from: tick{place: "client0", time: 5}, message: MutationRequest{invocation: {args: ["foo",10], name: "deposit"}, trace: [Read{key: "foo", transactionID: "-1"},Write{key: "foo", value: 10}], txnID: "10698"}, to: tick{place: "server", time: 7}}.
+hop{from: tick{place: "client0", time: 5}, message: MutationRequest{interpState: {randSeed: 2502798}, invocation: {args: ["foo",10], name: "deposit"}, trace: [Read{key: "foo", transactionID: "-1"},Write{key: "foo", value: 10}], txnID: "10698"}, to: tick{place: "server", time: 7}}.
 hop{from: tick{place: "server", time: 7}, message: MutationResponse{payload: Accept{timestamp: 0}, txnID: "10698"}, to: tick{place: "client0", time: 9}}.
 hop{from: tick{place: "user0", time: 10}, message: RunMutation{invocation: {args: ["bar",10], name: "deposit"}}, to: tick{place: "client0", time: 12}}.
-hop{from: tick{place: "client0", time: 12}, message: MutationRequest{invocation: {args: ["bar",10], name: "deposit"}, trace: [Read{key: "bar", transactionID: "-1"},Write{key: "bar", value: 10}], txnID: "2502798"}, to: tick{place: "server", time: 14}}.
-hop{from: tick{place: "server", time: 14}, message: MutationResponse{payload: Accept{timestamp: 1}, txnID: "2502798"}, to: tick{place: "client0", time: 16}}.
+hop{from: tick{place: "client0", time: 12}, message: MutationRequest{interpState: {randSeed: 5046918}, invocation: {args: ["bar",10], name: "deposit"}, trace: [Read{key: "bar", transactionID: "-1"},Write{key: "bar", value: 10}], txnID: "4540893"}, to: tick{place: "server", time: 14}}.
+hop{from: tick{place: "server", time: 14}, message: MutationResponse{payload: Accept{timestamp: 1}, txnID: "4540893"}, to: tick{place: "client0", time: 16}}.
 hop{from: tick{place: "user0", time: 17}, message: RunMutation{invocation: {args: ["foo","bar",5], name: "move"}}, to: tick{place: "client0", time: 19}}.
-hop{from: tick{place: "client0", time: 19}, message: MutationRequest{invocation: {args: ["foo","bar",5], name: "move"}, trace: [Read{key: "foo", transactionID: "10698"},Read{key: "bar", transactionID: "2502798"},Write{key: "foo", value: 5},Write{key: "bar", value: 15}], txnID: "4540893"}, to: tick{place: "server", time: 21}}.
-hop{from: tick{place: "server", time: 21}, message: MutationResponse{payload: Accept{timestamp: 2}, txnID: "4540893"}, to: tick{place: "client0", time: 23}}.
+hop{from: tick{place: "client0", time: 19}, message: MutationRequest{interpState: {randSeed: 746088}, invocation: {args: ["foo","bar",5], name: "move"}, trace: [Read{key: "foo", transactionID: "10698"},Read{key: "bar", transactionID: "4540893"},Write{key: "foo", value: 5},Write{key: "bar", value: 15}], txnID: "3045903"}, to: tick{place: "server", time: 21}}.
+hop{from: tick{place: "server", time: 21}, message: MutationResponse{payload: Accept{timestamp: 2}, txnID: "3045903"}, to: tick{place: "client0", time: 23}}.
 hop{from: tick{place: "user0", time: 24}, message: RunMutation{invocation: {args: ["foo","bar",5], name: "move"}}, to: tick{place: "client0", time: 26}}.
-hop{from: tick{place: "client0", time: 26}, message: MutationRequest{invocation: {args: ["foo","bar",5], name: "move"}, trace: [Read{key: "foo", transactionID: "4540893"},Read{key: "bar", transactionID: "4540893"},Write{key: "foo", value: 0},Write{key: "bar", value: 20}], txnID: "5046918"}, to: tick{place: "server", time: 28}}.
-hop{from: tick{place: "server", time: 28}, message: MutationResponse{payload: Accept{timestamp: 3}, txnID: "5046918"}, to: tick{place: "client0", time: 30}}.
+hop{from: tick{place: "client0", time: 26}, message: MutationRequest{interpState: {randSeed: 1974273}, invocation: {args: ["foo","bar",5], name: "move"}, trace: [Read{key: "foo", transactionID: "3045903"},Read{key: "bar", transactionID: "3045903"},Write{key: "foo", value: 0},Write{key: "bar", value: 20}], txnID: "1820643"}, to: tick{place: "server", time: 28}}.
+hop{from: tick{place: "server", time: 28}, message: MutationResponse{payload: Accept{timestamp: 3}, txnID: "1820643"}, to: tick{place: "client0", time: 30}}.

--- a/apps/actors/systems/kvSync/examples/chat.tsx
+++ b/apps/actors/systems/kvSync/examples/chat.tsx
@@ -272,6 +272,7 @@ const mutations: MutationDefns = {
             varr("newSeqNo"),
           ]),
           obj({
+            id: apply("rand", []),
             seqNo: varr("newSeqNo"),
             sender: varr("curUser"),
             message: varr("message"),

--- a/apps/actors/systems/kvSync/examples/chat.tsx
+++ b/apps/actors/systems/kvSync/examples/chat.tsx
@@ -19,6 +19,7 @@ import { TxnState } from "./common";
 import { KVApp } from "./types";
 
 type Message = {
+  id: number;
   seqNo: number;
   sender: string;
   message: string;
@@ -99,30 +100,34 @@ function MessageTable(props: { threadID: string; client: Client }) {
           </tr>
         </thead>
         <tbody>
-          {/* sort by date? */}
-          {Object.values(messages).map((message) => {
-            const msg = message.value as Message;
-            return (
-              <tr key={message.transactionID}>
-                <td>{msg.sender}</td>
-                <td>{msg.message}</td>
-                <td>
-                  <TxnState
-                    client={props.client}
-                    txnID={message.transactionID}
-                  />
-                </td>
-                <td>
-                  {(usersSeenBySeqNo[msg.seqNo] || [])
-                    .filter(
-                      (user) =>
-                        user !== props.client.state.id && user !== msg.sender
-                    )
-                    .join(", ")}
-                </td>
-              </tr>
-            );
-          })}
+          {/* TODO: index by seq no so we don't have to do this here? */}
+          {Object.values(messages)
+            .sort(
+              (a, b) => (a.value as Message).seqNo - (b.value as Message).seqNo
+            )
+            .map((message) => {
+              const msg = message.value as Message;
+              return (
+                <tr key={message.transactionID}>
+                  <td>{msg.sender}</td>
+                  <td>{msg.message}</td>
+                  <td>
+                    <TxnState
+                      client={props.client}
+                      txnID={message.transactionID}
+                    />
+                  </td>
+                  <td>
+                    {(usersSeenBySeqNo[msg.seqNo] || [])
+                      .filter(
+                        (user) =>
+                          user !== props.client.state.id && user !== msg.sender
+                      )
+                      .join(", ")}
+                  </td>
+                </tr>
+              );
+            })}
         </tbody>
       </table>
     </>
@@ -239,6 +244,10 @@ const mutations: MutationDefns = {
           varName: "newSeqNo",
           val: apply("+", [varr("latestSeqNo"), int(1)]),
         },
+        {
+          varName: "newID",
+          val: apply("rand", []),
+        },
       ],
       doExpr([
         write(
@@ -269,10 +278,10 @@ const mutations: MutationDefns = {
             str("/messages/"),
             varr("threadID"),
             str("/"),
-            varr("newSeqNo"),
+            varr("newID"),
           ]),
           obj({
-            id: apply("rand", []),
+            id: varr("newID"),
             seqNo: varr("newSeqNo"),
             sender: varr("curUser"),
             message: varr("message"),

--- a/apps/actors/systems/kvSync/mutations/builtins.ts
+++ b/apps/actors/systems/kvSync/mutations/builtins.ts
@@ -3,7 +3,6 @@ import { Value } from "./types";
 
 export type InterpreterState = {
   randSeed: number;
-  timestamp: number;
 };
 
 // mutates InterpreterState

--- a/apps/actors/systems/kvSync/mutations/builtins.ts
+++ b/apps/actors/systems/kvSync/mutations/builtins.ts
@@ -1,24 +1,38 @@
+import { randStep } from "../../../../../util/util";
 import { Value } from "./types";
 
-export type Builtin = (args: Value[]) => Value;
+export type InterpreterState = {
+  randSeed: number;
+  timestamp: number;
+};
+
+// mutates InterpreterState
+export type Builtin = (
+  state: InterpreterState,
+  args: Value[]
+) => [Value, InterpreterState];
 
 export const BUILTINS: { [name: string]: Builtin } = {
-  "+": (args) => {
-    return (args[0] as number) + (args[1] as number);
+  "+": (state, args) => {
+    return [(args[0] as number) + (args[1] as number), state];
   },
-  "-": (args) => {
-    return (args[0] as number) - (args[1] as number);
+  "-": (state, args) => {
+    return [(args[0] as number) - (args[1] as number), state];
   },
-  "<": (args) => {
-    return args[0] < args[1];
+  "<": (state, args) => {
+    return [args[0] < args[1], state];
   },
-  ">": (args) => {
-    return args[0] > args[1];
+  ">": (state, args) => {
+    return [args[0] > args[1], state];
   },
-  concat: (args) => {
-    return args.join("");
+  concat: (state, args) => {
+    return [args.join(""), state];
   },
-  parseInt: (args) => {
-    return parseInt(args[0] as string);
+  parseInt: (state, args) => {
+    return [parseInt(args[0] as string), state];
+  },
+  rand: (state, args) => {
+    const newSeed = randStep(state.randSeed);
+    return [newSeed, { ...state, randSeed: newSeed }];
   },
 };

--- a/apps/actors/systems/kvSync/server.ts
+++ b/apps/actors/systems/kvSync/server.ts
@@ -71,8 +71,9 @@ function runMutationOnServer(
   req: MutationRequest,
   clientID: string
 ): [ServerState, MutationResponse, LiveQueryUpdate[]] {
-  const [newData, outcome, trace] = runMutation(
+  const [newData, newInterpState, outcome, trace] = runMutation(
     state.data,
+    req.interpState,
     req.txnID,
     state.mutationDefns[req.invocation.name],
     req.invocation.args,

--- a/apps/actors/systems/kvSync/server.ts
+++ b/apps/actors/systems/kvSync/server.ts
@@ -14,7 +14,7 @@ import {
   WriteOp,
 } from "./types";
 import * as effects from "../../effects";
-import { filterMap, filterObj, groupBy } from "../../../../util/util";
+import { filterMap } from "../../../../util/util";
 import { jsonEq } from "../../../../util/json";
 import { runMutation } from "./mutations/run";
 import { keyInQuery, runQuery } from "./query";

--- a/apps/actors/systems/kvSync/types.ts
+++ b/apps/actors/systems/kvSync/types.ts
@@ -1,4 +1,5 @@
 import { Json } from "../../../../util/json";
+import { InterpreterState } from "./mutations/builtins";
 import { Lambda } from "./mutations/types";
 
 export type VersionedValue = {
@@ -43,6 +44,7 @@ export type WriteOp = {
 export type MutationRequest = {
   type: "MutationRequest";
   txnID: string;
+  interpState: InterpreterState;
   invocation: MutationInvocation;
   trace: Trace;
 };


### PR DESCRIPTION
<img width="904" alt="image" src="https://user-images.githubusercontent.com/7341/201575598-91e74065-2d31-4a87-86b6-83d1e5b8d38f.png">

Allows a failed message to not get overwritten by a successful one with the same seqNo.

Now we'll be able to resend