### PR TITLE
Vscode trigger characters

### DIFF
--- a/apps/vscodeExtension/package.json
+++ b/apps/vscodeExtension/package.json
@@ -2,7 +2,7 @@
   "name": "lingo",
   "displayName": "Lingo",
   "publisher": "lingo",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "repository": {
     "type": "git",
     "url": "https://github.com/vilterp/datalog-ts"

--- a/languageWorkbench/languages/index.ts
+++ b/languageWorkbench/languages/index.ts
@@ -91,6 +91,8 @@ export const LANGUAGES: { [name: string]: LanguageSpec } = {
     datalog: datalogDL,
     grammar: datalogGrammar,
     example: datalogExample,
+    // TODO: derive these from the grammar
+    triggerCharacters: ["&", "|", "-", ":", "{", ","],
   },
   json: {
     name: "json",
@@ -147,4 +149,5 @@ export type LanguageSpec = {
   datalog: string;
   grammar: string;
   example: string;
+  triggerCharacters?: string[]; // TODO: put into DL itself or derive from grammar
 };

--- a/languageWorkbench/vscode/monacoIntegration.ts
+++ b/languageWorkbench/vscode/monacoIntegration.ts
@@ -69,12 +69,6 @@ export function registerLanguageSupport(
   );
 
   // completions
-  console.log(
-    "registering language",
-    spec.name,
-    "with trigger characters",
-    spec.triggerCharacters
-  );
   subscriptions.push(
     monacoInstance.languages.registerCompletionItemProvider(spec.name, {
       triggerCharacters: spec.triggerCharacters,

--- a/languageWorkbench/vscode/monacoIntegration.ts
+++ b/languageWorkbench/vscode/monacoIntegration.ts
@@ -59,9 +59,6 @@ export function registerLanguageSupport(
         position: monaco.Position,
         token: monaco.CancellationToken
       ): monaco.languages.ProviderResult<monaco.languages.DocumentHighlight[]> {
-        if (token.isCancellationRequested) {
-          return [];
-        }
         try {
           return getHighlights(spec, document, position, token);
         } catch (e) {
@@ -149,9 +146,6 @@ export function registerLanguageSupport(
         lastResultId: string | null,
         token: monaco.CancellationToken
       ): monaco.languages.ProviderResult<monaco.languages.SemanticTokens> {
-        if (token.isCancellationRequested) {
-          throw new Error("cancelled");
-        }
         try {
           const before = new Date().getTime();
           const tokens = getSemanticTokens(spec, model, token);

--- a/languageWorkbench/vscode/monacoIntegration.ts
+++ b/languageWorkbench/vscode/monacoIntegration.ts
@@ -59,6 +59,9 @@ export function registerLanguageSupport(
         position: monaco.Position,
         token: monaco.CancellationToken
       ): monaco.languages.ProviderResult<monaco.languages.DocumentHighlight[]> {
+        if (token.isCancellationRequested) {
+          return [];
+        }
         try {
           return getHighlights(spec, document, position, token);
         } catch (e) {
@@ -69,8 +72,15 @@ export function registerLanguageSupport(
   );
 
   // completions
+  console.log(
+    "registering language",
+    spec.name,
+    "with trigger characters",
+    spec.triggerCharacters
+  );
   subscriptions.push(
     monacoInstance.languages.registerCompletionItemProvider(spec.name, {
+      triggerCharacters: spec.triggerCharacters,
       provideCompletionItems(
         model: monaco.editor.ITextModel,
         position: monaco.Position,
@@ -139,6 +149,9 @@ export function registerLanguageSupport(
         lastResultId: string | null,
         token: monaco.CancellationToken
       ): monaco.languages.ProviderResult<monaco.languages.SemanticTokens> {
+        if (token.isCancellationRequested) {
+          throw new Error("cancelled");
+        }
         try {
           const before = new Date().getTime();
           const tokens = getSemanticTokens(spec, model, token);

--- a/languageWorkbench/vscode/vscodeIntegration.ts
+++ b/languageWorkbench/vscode/vscodeIntegration.ts
@@ -69,20 +69,24 @@ export function registerLanguageSupport(
 
   // completions
   subscriptions.push(
-    vscode.languages.registerCompletionItemProvider(spec.name, {
-      provideCompletionItems(
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        token: vscode.CancellationToken,
-        context: vscode.CompletionContext
-      ): vscode.ProviderResult<vscode.CompletionItem[]> {
-        try {
-          return getCompletionItems(spec, document, position, token, context);
-        } catch (e) {
-          console.error("in completion provider:", e);
-        }
+    vscode.languages.registerCompletionItemProvider(
+      spec.name,
+      {
+        provideCompletionItems(
+          document: vscode.TextDocument,
+          position: vscode.Position,
+          token: vscode.CancellationToken,
+          context: vscode.CompletionContext
+        ): vscode.ProviderResult<vscode.CompletionItem[]> {
+          try {
+            return getCompletionItems(spec, document, position, token, context);
+          } catch (e) {
+            console.error("in completion provider:", e);
+          }
+        },
       },
-    })
+      ...(spec.triggerCharacters || [])
+    )
   );
 
   // renames
@@ -141,6 +145,10 @@ export function registerLanguageSupport(
           document: vscode.TextDocument,
           token: vscode.CancellationToken
         ): vscode.ProviderResult<vscode.SemanticTokens> {
+          if (token.isCancellationRequested) {
+            console.log("cancelled: provideDocumentSemanticTokens");
+            return null;
+          }
           try {
             const before = new Date().getTime();
             const tokens = getSemanticTokens(spec, document, token);

--- a/languageWorkbench/vscode/vscodeIntegration.ts
+++ b/languageWorkbench/vscode/vscodeIntegration.ts
@@ -145,10 +145,6 @@ export function registerLanguageSupport(
           document: vscode.TextDocument,
           token: vscode.CancellationToken
         ): vscode.ProviderResult<vscode.SemanticTokens> {
-          if (token.isCancellationRequested) {
-            console.log("cancelled: provideDocumentSemanticTokens");
-            return null;
-          }
           try {
             const before = new Date().getTime();
             const tokens = getSemanticTokens(spec, document, token);


### PR DESCRIPTION
Tell VSCode to request completion items when we hit certain characters.

This enables you to type a whole rule without requesting completion or retyping an identifier:

https://user-images.githubusercontent.com/7341/204229126-bfd72cab-94a9-466e-a08a-e8d14813cdc1.mov

TODO:
- [ ] whitespace
- [ ] monaco as well as vscode
- [ ] (later PR?) auto-derive from grammar