### PR TITLE
clear interp cache between benchmarks

### DIFF
--- a/languageWorkbench/ddTests.ts
+++ b/languageWorkbench/ddTests.ts
@@ -90,6 +90,8 @@ export function testLangQuery(
     } catch (e) {
       console.log(e);
       throw new Error(`failed on input "${input}"`);
+    } finally {
+      clearInterpCache();
     }
   });
 }


### PR DESCRIPTION
Making it actually use simple vs incr