### PR TITLE
add ref edges to dl parse state graph

### DIFF
--- a/languageWorkbench/parserlib/datalog/parse.dl
+++ b/languageWorkbench/parserlib/datalog/parse.dl
@@ -260,8 +260,8 @@ viz.stateNode{st: st{state: S, char: C}} :-
   parse.State{state: S, char: C}.
 
 viz.stateGraphEdge{from: From, to: To, type: Type} :-
-  parse.stateStep{from: From, to: To, type: Type}.
-  # viz.parentEdge{from: From, to: To, type: Type}.
+  parse.stateStep{from: From, to: To, type: Type} |
+  parse.refStep{from: From, to: To, rule: Type}.
 
 internal.visualization{
   name: "State Graph",


### PR DESCRIPTION
See the entire parse trace, e.g. of parsing `{'foo':2}` as JSON:

<img width="775" alt="image" src="https://user-images.githubusercontent.com/7341/212533517-7c0765eb-afbf-453e-ad5a-acc43f38724b.png">
