### PR TITLE
use new `maxBy` aggregator to select longest parse for given rule at given start char

### DIFF
--- a/languageWorkbench/parserlib/datalog/parse.dl
+++ b/languageWorkbench/parserlib/datalog/parse.dl
@@ -116,11 +116,11 @@ parse.refStep{
     to: st{state: RuleStartSt, char: FromC},
     rule: Rule,
   } &
-  parse.statePathWithinRule{
+  maxBy[RuleStartSt, FromC, RuleEndSt, ToC, L: parse.statePathWithinRule{
     from: st{state: RuleStartSt, char: FromC},
     to: st{state: RuleEndSt, char: ToC},
     length: L,
-  } &
+  }] &
   parse.returnFromRule{
     from: st{state: RuleEndSt, char: ToC},
     to: st{state: ToS, char: ToC}

--- a/languageWorkbench/parserlib/datalog/parse.dl
+++ b/languageWorkbench/parserlib/datalog/parse.dl
@@ -139,6 +139,9 @@ parse.jump{
 # building rule tree
 
 parse.ruleMatch{rule: Rule, span: span{from: CStart, to: CEnd}, length: L} :-
+  maxBy[Rule, CStart, L: parse.rawRuleMatch{rule: Rule, span: span{from: CStart, to: CEnd}, length: L}].
+
+parse.rawRuleMatch{rule: Rule, span: span{from: CStart, to: CEnd}, length: L} :-
   grammar.rule{name: Rule, from: SRuleStart, to: SRuleEnd} &
   parse.State{state: SRuleStart, char: CStart} &
   parse.State{state: SRuleEnd, char: CEnd} &

--- a/languageWorkbench/parserlib/datalog/parse.dl
+++ b/languageWorkbench/parserlib/datalog/parse.dl
@@ -20,20 +20,21 @@ parse.State{state: S, char: C} :-
 # state path
 
 # TODO: use individual steps instead of this
-parse.statePathWithinRule{from: From, to: To} :-
-  parse.sameState{from: From, to: To} |
-  parse.stateStepWithinRule{from: From, to: To} |
-  parse.stateStepWithinRule{from: From, to: Between} &
-  parse.statePathWithinRule{from: Between, to: To}.
+parse.statePathWithinRule{from: From, to: To, length: L} :-
+  parse.sameState{from: From, to: To, length: L} |
+  parse.stateStepWithinRule{from: From, to: To, length: L} |
+  parse.stateStepWithinRule{from: From, to: Between, length: L1} &
+  parse.statePathWithinRule{from: Between, to: To, length: L2} &
+  L = L1 + L2.
 
-parse.sameState{from: st{state: S, char: C}, to: st{state: S, char: C}} :-
+parse.sameState{from: st{state: S, char: C}, to: st{state: S, char: C}, length: 0} :-
   parse.State{state: S, char: C}.
 
 # state step
 
-parse.stateStepWithinRule{from: From, to: To} :-
-  parse.nonCallStep{from: From, to: To, type: T} |
-  parse.refStep{from: From, to: To, type: T}.
+parse.stateStepWithinRule{from: From, to: To, length: L} :-
+  parse.nonCallStep{from: From, to: To, type: T, length: L} |
+  parse.refStep{from: From, to: To, type: T, length: L}.
 
 parse.stateStep{from: From, to: To, type: T} :-
   parse.nonCallStep{from: From, to: To, type: T} |
@@ -44,6 +45,7 @@ parse.initialStateStep{
   from: st{state: -1, char: -1},
   to: st{state: S, char: C},
   type: "initial",
+  length: 0,
 } :-
   grammar.rule{name: "main", from: S} &
   input.next{from: -1, to: C}.
@@ -52,6 +54,7 @@ parse.matchCharLiteral{
   from: st{state: FromS, char: FromC},
   to: st{state: ToS, char: ToC},
   type: "matchCharLiteral",
+  length: 1,
 } :-
   parse.State{state: FromS, char: FromC} &
   grammar.charLiteralEdge{from: FromS, to: ToS, val: V} &
@@ -62,6 +65,7 @@ parse.matchCharRange{
   from: st{state: FromS, char: FromC},
   to: st{state: ToS, char: ToC},
   type: "matchCharRange",
+  length: 1,
 } :-
   parse.State{state: FromS, char: FromC} &
   grammar.charRangeEdge{from: FromS, to: ToS, rangeStart: RS, rangeEnd: RE} &
@@ -105,6 +109,7 @@ parse.refStep{
   to: st{state: ToS, char: ToC},
   rule: Rule,
   type: "ref",
+  length: L,
 } :-
   parse.callRule{
     from: st{state: FromS, char: FromC},
@@ -114,6 +119,7 @@ parse.refStep{
   parse.statePathWithinRule{
     from: st{state: RuleStartSt, char: FromC},
     to: st{state: RuleEndSt, char: ToC},
+    length: L,
   } &
   parse.returnFromRule{
     from: st{state: RuleEndSt, char: ToC},
@@ -125,26 +131,28 @@ parse.jump{
   from: st{state: FromS, char: C},
   to: st{state: ToS, char: C},
   type: "jump",
+  length: 0,
 } :-
   parse.State{state: FromS, char: C} &
   grammar.jumpEdge{from: FromS, to: ToS}.
 
 # building rule tree
 
-parse.ruleMatch{rule: Rule, span: span{from: CStart, to: CEnd}} :-
+parse.ruleMatch{rule: Rule, span: span{from: CStart, to: CEnd}, length: L} :-
   grammar.rule{name: Rule, from: SRuleStart, to: SRuleEnd} &
   parse.State{state: SRuleStart, char: CStart} &
   parse.State{state: SRuleEnd, char: CEnd} &
   parse.statePathWithinRule{
     from: st{state: SRuleStart, char: CStart},
     to: st{state: SRuleEnd, char: CEnd},
+    length: L,
   }.
 
-parse.nonCallStep{from: From, to: To, type: T} :-
-  parse.initialStateStep{from: From, to: To, type: T} |
-  parse.matchCharLiteral{from: From, to: To, type: T} |
-  parse.matchCharRange{from: From, to: To, type: T} |
-  parse.jump{from: From, to: To, type: T}.
+parse.nonCallStep{from: From, to: To, type: T, length: L} :-
+  parse.initialStateStep{from: From, to: To, type: T, length: L} |
+  parse.matchCharLiteral{from: From, to: To, type: T, length: L} |
+  parse.matchCharRange{from: From, to: To, type: T, length: L} |
+  parse.jump{from: From, to: To, type: T, length: L}.
 
 parse.ruleMatchParent{
   child: match{rule: ChildRule, span: span{from: ChildStartCh, to: ChildEndCh}},
@@ -191,22 +199,23 @@ grammar.stateDirectlyReachable{from: StateFrom, to: StateTo} :-
 viz.astNode{
   id: match{rule: R, span: span{from: F, to: T}},
   parentID: P,
-  display: [R, [F, T]],
+  display: [R, [F, T], L],
 } :-
   viz.astNodeInternal{
     id: match{rule: R, span: span{from: F, to: T}},
     parentID: P,
+    length: L,
   }.
 
-viz.astNodeInternal{id: I, parentID: P} :-
-  viz.normalNode{id: I, parentID: P} |
-  viz.mainNode{id: I, parentID: P}.
+viz.astNodeInternal{id: I, parentID: P, length: L} :-
+  viz.normalNode{id: I, parentID: P, length: L} |
+  viz.mainNode{id: I, parentID: P, length: L}.
 
-viz.normalNode{id: match{rule: Rule, span: Span}, parentID: P} :-
-  parse.ruleMatch{rule: Rule, span: Span} &
+viz.normalNode{id: match{rule: Rule, span: Span}, parentID: P, length: L} :-
+  parse.ruleMatch{rule: Rule, span: Span, length: L} &
   parse.ruleMatchParent{child: match{rule: Rule, span: Span}, parent: P}.
-viz.mainNode{id: match{rule: "main", span: Span}, parentID: -1} :-
-  parse.ruleMatch{rule: "main", span: Span}.
+viz.mainNode{id: match{rule: "main", span: Span}, parentID: -1, length: L} :-
+  parse.ruleMatch{rule: "main", span: Span, length: L}.
 
 internal.visualization{
   name: "AST",

--- a/languageWorkbench/parserlib/datalog/parse.dl
+++ b/languageWorkbench/parserlib/datalog/parse.dl
@@ -116,11 +116,11 @@ parse.refStep{
     to: st{state: RuleStartSt, char: FromC},
     rule: Rule,
   } &
-  maxBy[RuleStartSt, FromC, RuleEndSt, ToC, L: parse.statePathWithinRule{
+  parse.statePathWithinRule{
     from: st{state: RuleStartSt, char: FromC},
     to: st{state: RuleEndSt, char: ToC},
     length: L,
-  }] &
+  } &
   parse.returnFromRule{
     from: st{state: RuleEndSt, char: ToC},
     to: st{state: ToS, char: ToC}

--- a/languageWorkbench/parserlib/testdata/datalog.dd.txt
+++ b/languageWorkbench/parserlib/testdata/datalog.dd.txt
@@ -15,7 +15,7 @@ input
 foo
 ----
 application/datalog
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
+viz.astNode{display: ["main",[0,-2],3], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
 
 gram
 main :- ["a", "b", "c"].
@@ -34,7 +34,7 @@ input
 abc
 ----
 application/datalog
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
+viz.astNode{display: ["main",[0,-2],3], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
 
 gram
 main :- (foo | bar).
@@ -72,15 +72,15 @@ input
 foo
 ----
 application/datalog
-viz.astNode{display: ["foo",[0,-2]], id: match{rule: "foo", span: span{from: 0, to: -2}}, parentID: match{rule: "main", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
+viz.astNode{display: ["foo",[0,-2],3], id: match{rule: "foo", span: span{from: 0, to: -2}}, parentID: match{rule: "main", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["main",[0,-2],3], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
 
 input
 bar
 ----
 application/datalog
-viz.astNode{display: ["bar",[0,-2]], id: match{rule: "bar", span: span{from: 0, to: -2}}, parentID: match{rule: "main", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
+viz.astNode{display: ["bar",[0,-2],3], id: match{rule: "bar", span: span{from: 0, to: -2}}, parentID: match{rule: "main", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["main",[0,-2],3], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
 
 gram
 main :- repSep("foo", "bar").
@@ -107,28 +107,21 @@ input
 foo
 ----
 application/datalog
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[0,0]], id: match{rule: "main", span: span{from: 0, to: 0}}, parentID: -1}.
+viz.astNode{display: ["main",[0,-2],3], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
 
 input
 foobar
 ----
 application/datalog
-viz.astNode{display: ["main",[-2,-2]], id: match{rule: "main", span: span{from: -2, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[0,0]], id: match{rule: "main", span: span{from: 0, to: 0}}, parentID: -1}.
-viz.astNode{display: ["main",[0,3]], id: match{rule: "main", span: span{from: 0, to: 3}}, parentID: -1}.
+viz.astNode{display: ["main",[-2,-2],0], id: match{rule: "main", span: span{from: -2, to: -2}}, parentID: -1}.
+viz.astNode{display: ["main",[0,-2],6], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
 
 input
 foobarfoo
 ----
 application/datalog
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[0,0]], id: match{rule: "main", span: span{from: 0, to: 0}}, parentID: -1}.
-viz.astNode{display: ["main",[0,3]], id: match{rule: "main", span: span{from: 0, to: 3}}, parentID: -1}.
-viz.astNode{display: ["main",[0,6]], id: match{rule: "main", span: span{from: 0, to: 6}}, parentID: -1}.
-viz.astNode{display: ["main",[6,-2]], id: match{rule: "main", span: span{from: 6, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[6,6]], id: match{rule: "main", span: span{from: 6, to: 6}}, parentID: -1}.
+viz.astNode{display: ["main",[0,-2],9], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
+viz.astNode{display: ["main",[6,-2],3], id: match{rule: "main", span: span{from: 6, to: -2}}, parentID: -1}.
 
 gram
 main :- ["[", repSep([a-z], ","), "]"].
@@ -151,7 +144,7 @@ input
 [a,b,c]
 ----
 application/datalog
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
+viz.astNode{display: ["main",[0,-2],7], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
 
 gram
 main :- repSep([0-9], "").
@@ -168,24 +161,17 @@ input
 1
 ----
 application/datalog
-viz.astNode{display: ["main",[-2,-2]], id: match{rule: "main", span: span{from: -2, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[0,0]], id: match{rule: "main", span: span{from: 0, to: 0}}, parentID: -1}.
+viz.astNode{display: ["main",[-2,-2],0], id: match{rule: "main", span: span{from: -2, to: -2}}, parentID: -1}.
+viz.astNode{display: ["main",[0,-2],1], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
 
 input
 123
 ----
 application/datalog
-viz.astNode{display: ["main",[-2,-2]], id: match{rule: "main", span: span{from: -2, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[0,0]], id: match{rule: "main", span: span{from: 0, to: 0}}, parentID: -1}.
-viz.astNode{display: ["main",[0,1]], id: match{rule: "main", span: span{from: 0, to: 1}}, parentID: -1}.
-viz.astNode{display: ["main",[0,2]], id: match{rule: "main", span: span{from: 0, to: 2}}, parentID: -1}.
-viz.astNode{display: ["main",[1,-2]], id: match{rule: "main", span: span{from: 1, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[1,1]], id: match{rule: "main", span: span{from: 1, to: 1}}, parentID: -1}.
-viz.astNode{display: ["main",[1,2]], id: match{rule: "main", span: span{from: 1, to: 2}}, parentID: -1}.
-viz.astNode{display: ["main",[2,-2]], id: match{rule: "main", span: span{from: 2, to: -2}}, parentID: -1}.
-viz.astNode{display: ["main",[2,2]], id: match{rule: "main", span: span{from: 2, to: 2}}, parentID: -1}.
+viz.astNode{display: ["main",[-2,-2],0], id: match{rule: "main", span: span{from: -2, to: -2}}, parentID: -1}.
+viz.astNode{display: ["main",[0,-2],3], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
+viz.astNode{display: ["main",[1,-2],2], id: match{rule: "main", span: span{from: 1, to: -2}}, parentID: -1}.
+viz.astNode{display: ["main",[2,-2],1], id: match{rule: "main", span: span{from: 2, to: -2}}, parentID: -1}.
 
 gram
 main :- value.
@@ -285,42 +271,42 @@ input
 null
 ----
 application/datalog
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
-viz.astNode{display: ["null",[0,-2]], id: match{rule: "null", span: span{from: 0, to: -2}}, parentID: match{rule: "value", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["value",[0,-2]], id: match{rule: "value", span: span{from: 0, to: -2}}, parentID: match{rule: "main", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["main",[0,-2],4], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
+viz.astNode{display: ["null",[0,-2],4], id: match{rule: "null", span: span{from: 0, to: -2}}, parentID: match{rule: "value", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["value",[0,-2],4], id: match{rule: "value", span: span{from: 0, to: -2}}, parentID: match{rule: "main", span: span{from: 0, to: -2}}}.
 
 input
 [1,2,3]
 ----
 application/datalog
-viz.astNode{display: ["array",[0,-2]], id: match{rule: "array", span: span{from: 0, to: -2}}, parentID: match{rule: "value", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["int",[1,2]], id: match{rule: "int", span: span{from: 1, to: 2}}, parentID: match{rule: "value", span: span{from: 1, to: 2}}}.
-viz.astNode{display: ["int",[3,4]], id: match{rule: "int", span: span{from: 3, to: 4}}, parentID: match{rule: "value", span: span{from: 3, to: 4}}}.
-viz.astNode{display: ["int",[5,6]], id: match{rule: "int", span: span{from: 5, to: 6}}, parentID: match{rule: "value", span: span{from: 5, to: 6}}}.
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
-viz.astNode{display: ["value",[0,-2]], id: match{rule: "value", span: span{from: 0, to: -2}}, parentID: match{rule: "main", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["value",[1,2]], id: match{rule: "value", span: span{from: 1, to: 2}}, parentID: match{rule: "array", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["value",[3,4]], id: match{rule: "value", span: span{from: 3, to: 4}}, parentID: match{rule: "array", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["value",[5,6]], id: match{rule: "value", span: span{from: 5, to: 6}}, parentID: match{rule: "array", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["array",[0,-2],7], id: match{rule: "array", span: span{from: 0, to: -2}}, parentID: match{rule: "value", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["int",[1,2],1], id: match{rule: "int", span: span{from: 1, to: 2}}, parentID: match{rule: "value", span: span{from: 1, to: 2}}}.
+viz.astNode{display: ["int",[3,4],1], id: match{rule: "int", span: span{from: 3, to: 4}}, parentID: match{rule: "value", span: span{from: 3, to: 4}}}.
+viz.astNode{display: ["int",[5,6],1], id: match{rule: "int", span: span{from: 5, to: 6}}, parentID: match{rule: "value", span: span{from: 5, to: 6}}}.
+viz.astNode{display: ["main",[0,-2],7], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
+viz.astNode{display: ["value",[0,-2],7], id: match{rule: "value", span: span{from: 0, to: -2}}, parentID: match{rule: "main", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["value",[1,2],1], id: match{rule: "value", span: span{from: 1, to: 2}}, parentID: match{rule: "array", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["value",[3,4],1], id: match{rule: "value", span: span{from: 3, to: 4}}, parentID: match{rule: "array", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["value",[5,6],1], id: match{rule: "value", span: span{from: 5, to: 6}}, parentID: match{rule: "array", span: span{from: 0, to: -2}}}.
 
 input
 {'foo':2,'bar':[1,2,3]}
 ----
 application/datalog
-viz.astNode{display: ["array",[15,22]], id: match{rule: "array", span: span{from: 15, to: 22}}, parentID: match{rule: "value", span: span{from: 15, to: 22}}}.
-viz.astNode{display: ["int",[16,17]], id: match{rule: "int", span: span{from: 16, to: 17}}, parentID: match{rule: "value", span: span{from: 16, to: 17}}}.
-viz.astNode{display: ["int",[18,19]], id: match{rule: "int", span: span{from: 18, to: 19}}, parentID: match{rule: "value", span: span{from: 18, to: 19}}}.
-viz.astNode{display: ["int",[20,21]], id: match{rule: "int", span: span{from: 20, to: 21}}, parentID: match{rule: "value", span: span{from: 20, to: 21}}}.
-viz.astNode{display: ["int",[7,8]], id: match{rule: "int", span: span{from: 7, to: 8}}, parentID: match{rule: "value", span: span{from: 7, to: 8}}}.
-viz.astNode{display: ["keyValue",[1,8]], id: match{rule: "keyValue", span: span{from: 1, to: 8}}, parentID: match{rule: "object", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["keyValue",[9,22]], id: match{rule: "keyValue", span: span{from: 9, to: 22}}, parentID: match{rule: "object", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["main",[0,-2]], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
-viz.astNode{display: ["object",[0,-2]], id: match{rule: "object", span: span{from: 0, to: -2}}, parentID: match{rule: "value", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["string",[1,6]], id: match{rule: "string", span: span{from: 1, to: 6}}, parentID: match{rule: "keyValue", span: span{from: 1, to: 8}}}.
-viz.astNode{display: ["string",[9,14]], id: match{rule: "string", span: span{from: 9, to: 14}}, parentID: match{rule: "keyValue", span: span{from: 9, to: 22}}}.
-viz.astNode{display: ["value",[0,-2]], id: match{rule: "value", span: span{from: 0, to: -2}}, parentID: match{rule: "main", span: span{from: 0, to: -2}}}.
-viz.astNode{display: ["value",[15,22]], id: match{rule: "value", span: span{from: 15, to: 22}}, parentID: match{rule: "keyValue", span: span{from: 9, to: 22}}}.
-viz.astNode{display: ["value",[16,17]], id: match{rule: "value", span: span{from: 16, to: 17}}, parentID: match{rule: "array", span: span{from: 15, to: 22}}}.
-viz.astNode{display: ["value",[18,19]], id: match{rule: "value", span: span{from: 18, to: 19}}, parentID: match{rule: "array", span: span{from: 15, to: 22}}}.
-viz.astNode{display: ["value",[20,21]], id: match{rule: "value", span: span{from: 20, to: 21}}, parentID: match{rule: "array", span: span{from: 15, to: 22}}}.
-viz.astNode{display: ["value",[7,8]], id: match{rule: "value", span: span{from: 7, to: 8}}, parentID: match{rule: "keyValue", span: span{from: 1, to: 8}}}.
+viz.astNode{display: ["array",[15,22],7], id: match{rule: "array", span: span{from: 15, to: 22}}, parentID: match{rule: "value", span: span{from: 15, to: 22}}}.
+viz.astNode{display: ["int",[16,17],1], id: match{rule: "int", span: span{from: 16, to: 17}}, parentID: match{rule: "value", span: span{from: 16, to: 17}}}.
+viz.astNode{display: ["int",[18,19],1], id: match{rule: "int", span: span{from: 18, to: 19}}, parentID: match{rule: "value", span: span{from: 18, to: 19}}}.
+viz.astNode{display: ["int",[20,21],1], id: match{rule: "int", span: span{from: 20, to: 21}}, parentID: match{rule: "value", span: span{from: 20, to: 21}}}.
+viz.astNode{display: ["int",[7,8],1], id: match{rule: "int", span: span{from: 7, to: 8}}, parentID: match{rule: "value", span: span{from: 7, to: 8}}}.
+viz.astNode{display: ["keyValue",[1,8],7], id: match{rule: "keyValue", span: span{from: 1, to: 8}}, parentID: match{rule: "object", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["keyValue",[9,22],13], id: match{rule: "keyValue", span: span{from: 9, to: 22}}, parentID: match{rule: "object", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["main",[0,-2],23], id: match{rule: "main", span: span{from: 0, to: -2}}, parentID: -1}.
+viz.astNode{display: ["object",[0,-2],23], id: match{rule: "object", span: span{from: 0, to: -2}}, parentID: match{rule: "value", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["string",[1,6],5], id: match{rule: "string", span: span{from: 1, to: 6}}, parentID: match{rule: "keyValue", span: span{from: 1, to: 8}}}.
+viz.astNode{display: ["string",[9,14],5], id: match{rule: "string", span: span{from: 9, to: 14}}, parentID: match{rule: "keyValue", span: span{from: 9, to: 22}}}.
+viz.astNode{display: ["value",[0,-2],23], id: match{rule: "value", span: span{from: 0, to: -2}}, parentID: match{rule: "main", span: span{from: 0, to: -2}}}.
+viz.astNode{display: ["value",[15,22],7], id: match{rule: "value", span: span{from: 15, to: 22}}, parentID: match{rule: "keyValue", span: span{from: 9, to: 22}}}.
+viz.astNode{display: ["value",[16,17],1], id: match{rule: "value", span: span{from: 16, to: 17}}, parentID: match{rule: "array", span: span{from: 15, to: 22}}}.
+viz.astNode{display: ["value",[18,19],1], id: match{rule: "value", span: span{from: 18, to: 19}}, parentID: match{rule: "array", span: span{from: 15, to: 22}}}.
+viz.astNode{display: ["value",[20,21],1], id: match{rule: "value", span: span{from: 20, to: 21}}, parentID: match{rule: "array", span: span{from: 15, to: 22}}}.
+viz.astNode{display: ["value",[7,8],1], id: match{rule: "value", span: span{from: 7, to: 8}}, parentID: match{rule: "keyValue", span: span{from: 1, to: 8}}}.


### PR DESCRIPTION
<img width="1904" alt="image" src="https://user-images.githubusercontent.com/7341/213902897-92d23a69-5253-4140-8cb8-d3783552783f.png">

thereby only getting one parse tree for main