### PR TITLE
LWB: fix highlighting across different kinds of vars

### DIFF
--- a/languageWorkbench/common/ide.dl
+++ b/languageWorkbench/common/ide.dl
@@ -83,8 +83,8 @@ ide.CurrentProblem{desc: D, span: span{from: F, to: T}} :-
 # === Highlight ===
 # TODO: consolidate a bit?
 
-ide.CurrentVar{scopeID: UsageScope, name: N, span: span{from: F, to: T}} :-
-  scope.Var{scopeID: UsageScope, name: N, span: span{from: F, to: T}} &
+ide.CurrentVar{scopeID: UsageScope, name: N, span: span{from: F, to: T}, kind: K} :-
+  scope.Var{scopeID: UsageScope, name: N, span: span{from: F, to: T}, kind: K} &
   ide.Cursor{idx: CIdx} &
   F <= CIdx & CIdx <= T.
 
@@ -96,21 +96,21 @@ ide.currentDefn{scopeID: DefnScope, name: N, span: span{from: F, to: T}} :-
   ide.Cursor{idx: CIdx} &
   F <= CIdx & CIdx <= T.
 ide.defnOfCurrentVar{span: S} :-
-  ide.CurrentVar{scopeID: UsageScope, name: N} &
-  scope.Item{scopeID: UsageScope, name: N, defnSpan: S}.
+  ide.CurrentVar{scopeID: UsageScope, name: N, kind: K} &
+  scope.Item{scopeID: UsageScope, name: N, kind: K, defnSpan: S}.
 
 ide.CurrentVarOrUsageOfCurrentDefn{type: "usage", span: S} :-
   ide.instanceOfCurrentVar{span: S} |
   ide.usageOfCurrentDefn{span: S}.
 ide.instanceOfCurrentVar{span: S} :-
   ide.CurrentVar{scopeID: CurrentVarScope, name: N, span: CVS} &
-  scope.Item{scopeID: CurrentVarScope, defnScopeID: DefnScope, name: N} &
-  scope.Item{scopeID: OtherVarScope, defnScopeID: DefnScope, name: N} &
-  scope.Var{scopeID: OtherVarScope, name: N, span: S}.
-ide.usageOfCurrentDefn{span: S} :-
-  ide.currentDefn{scopeID: DefnScope, name: N} &
-  scope.Item{scopeID: UsageScope, defnScopeID: DefnScope, name: N} &
-  scope.Var{scopeID: UsageScope, name: N, span: S}.
+  scope.Item{scopeID: CurrentVarScope, defnScopeID: DefnScope, name: N, kind: K} &
+  scope.Item{scopeID: OtherVarScope, defnScopeID: DefnScope, name: N, kind: K} &
+  scope.Var{scopeID: OtherVarScope, name: N, kind: K, span: S}.
+ide.usageOfCurrentDefn{span: UsageSpan} :-
+  ide.currentDefn{scopeID: DefnScope, name: N, span: DefnSpan} &
+  scope.Item{scopeID: UsageScope, defnScopeID: DefnScope, name: N, kind: K, defnSpan: DefnSpan} &
+  scope.Var{scopeID: UsageScope, name: N, kind: K, span: UsageSpan}.
 
 ide.CurrentUsageOrDefn{type: T, span: S} :-
   ide.CurrentDefnOrDefnOfCurrentVar{type: T, span: S} |

--- a/languageWorkbench/common/ide.dl
+++ b/languageWorkbench/common/ide.dl
@@ -103,7 +103,7 @@ ide.CurrentVarOrUsageOfCurrentDefn{type: "usage", span: S} :-
   ide.instanceOfCurrentVar{span: S} |
   ide.usageOfCurrentDefn{span: S}.
 ide.instanceOfCurrentVar{span: S} :-
-  ide.CurrentVar{scopeID: CurrentVarScope, name: N, span: CVS} &
+  ide.CurrentVar{scopeID: CurrentVarScope, name: N, span: CVS, kind: K} &
   scope.Item{scopeID: CurrentVarScope, defnScopeID: DefnScope, name: N, kind: K} &
   scope.Item{scopeID: OtherVarScope, defnScopeID: DefnScope, name: N, kind: K} &
   scope.Var{scopeID: OtherVarScope, name: N, kind: K, span: S}.

--- a/languageWorkbench/ddTests.ts
+++ b/languageWorkbench/ddTests.ts
@@ -79,13 +79,13 @@ export function testLangQuery(
     const finalInterp = addCursor(withoutCursor, cursorPos);
     try {
       const results = finalInterp.queryStr(query);
+      clearInterpCache();
       return datalogOut(results.map((res) => res.term));
     } catch (e) {
       console.log(e);
       throw new Error(`failed on input "${input}"`);
     }
   });
-  clearInterpCache();
   return output;
 }
 

--- a/languageWorkbench/languages/basicBlocks/basicBlocks.dd.txt
+++ b/languageWorkbench/languages/basicBlocks/basicBlocks.dd.txt
@@ -69,5 +69,4 @@ afterFork {}
 ide.CurrentUsageOrDefn{}?
 ----
 application/datalog
-ide.CurrentUsageOrDefn{span: span{from: 16, to: 25}, type: "usage"}.
 ide.CurrentUsageOrDefn{span: span{from: 29, to: 38}, type: "defn"}.

--- a/languageWorkbench/languages/basicBlocks/basicBlocks.dd.txt
+++ b/languageWorkbench/languages/basicBlocks/basicBlocks.dd.txt
@@ -82,3 +82,13 @@ ide.CurrentUsageOrDefn{}?
 application/datalog
 ide.CurrentUsageOrDefn{span: span{from: 16, to: 25}, type: "usage"}.
 ide.CurrentUsageOrDefn{span: span{from: 46, to: 55}, type: "defn"}.
+
+basicBlocks
+main {
+  forkTo afterFork;
+  x = foo(after|||Fork);
+}
+afterFork {}
+ide.CurrentUsageOrDefn{}?
+----
+application/datalog

--- a/languageWorkbench/languages/basicBlocks/basicBlocks.dd.txt
+++ b/languageWorkbench/languages/basicBlocks/basicBlocks.dd.txt
@@ -70,3 +70,15 @@ ide.CurrentUsageOrDefn{}?
 ----
 application/datalog
 ide.CurrentUsageOrDefn{span: span{from: 29, to: 38}, type: "defn"}.
+
+basicBlocks
+main {
+  forkTo afterFork;
+  afterFork = 5;
+}
+after|||Fork {}
+ide.CurrentUsageOrDefn{}?
+----
+application/datalog
+ide.CurrentUsageOrDefn{span: span{from: 16, to: 25}, type: "usage"}.
+ide.CurrentUsageOrDefn{span: span{from: 46, to: 55}, type: "defn"}.

--- a/languageWorkbench/languages/basicBlocks/basicBlocks.dd.txt
+++ b/languageWorkbench/languages/basicBlocks/basicBlocks.dd.txt
@@ -59,3 +59,15 @@ ast.ifClause{}?
 ----
 application/datalog
 ast.ifClause{id: 40, parentID: 27, rule: "ifClause", span: span{from: 27, to: 31}, text: "if a"}.
+
+basicBlocks
+main {
+  forkTo afterFork;
+  after|||Fork = 5;
+}
+afterFork {}
+ide.CurrentUsageOrDefn{}?
+----
+application/datalog
+ide.CurrentUsageOrDefn{span: span{from: 16, to: 25}, type: "usage"}.
+ide.CurrentUsageOrDefn{span: span{from: 29, to: 38}, type: "defn"}.


### PR DESCRIPTION
Putting the cursor over a label shouldn't highlight a var, and vice versa.

<img width="273" alt="image" src="https://github.com/vilterp/datalog-ts/assets/7341/578c8d9b-5752-4db4-ada1-72b3201372be">

<img width="289" alt="image" src="https://github.com/vilterp/datalog-ts/assets/7341/3a66482a-39ea-4297-8d94-eff7b052b1a2">
