### PR TITLE
wrap interp cache in a class

### DIFF
--- a/apps/fp/main.tsx
+++ b/apps/fp/main.tsx
@@ -6,10 +6,8 @@ import { useJSONLocalStorage } from "../../uiCommon/generic/hooks";
 import { initialEditorState } from "../../uiCommon/ide/types";
 import { LingoEditor } from "../../uiCommon/ide/editor";
 import { LANGUAGES } from "../../languageWorkbench/languages";
-import { InterpCache, addCursor } from "../../languageWorkbench/interpCache";
-import { INIT_INTERP } from "../../languageWorkbench/vscode/common";
-
-const CACHE = new InterpCache();
+import { addCursor } from "../../languageWorkbench/interpCache";
+import { CACHE } from "../../languageWorkbench/vscode/common";
 
 function Main() {
   const [editorState, setEditorState] = useJSONLocalStorage(
@@ -18,7 +16,6 @@ function Main() {
   );
 
   const { interp: withoutCursor } = CACHE.getInterpForDoc(
-    INIT_INTERP,
     "fp",
     { fp: LANGUAGES.fp },
     "test.fp",

--- a/apps/fp/main.tsx
+++ b/apps/fp/main.tsx
@@ -6,11 +6,10 @@ import { useJSONLocalStorage } from "../../uiCommon/generic/hooks";
 import { initialEditorState } from "../../uiCommon/ide/types";
 import { LingoEditor } from "../../uiCommon/ide/editor";
 import { LANGUAGES } from "../../languageWorkbench/languages";
-import {
-  addCursor,
-  getInterpForDoc,
-} from "../../languageWorkbench/interpCache";
+import { InterpCache, addCursor } from "../../languageWorkbench/interpCache";
 import { INIT_INTERP } from "../../languageWorkbench/vscode/common";
+
+const CACHE = new InterpCache();
 
 function Main() {
   const [editorState, setEditorState] = useJSONLocalStorage(
@@ -18,7 +17,7 @@ function Main() {
     initialEditorState("let x = 40 in plus2(y)")
   );
 
-  const { interp: withoutCursor } = getInterpForDoc(
+  const { interp: withoutCursor } = CACHE.getInterpForDoc(
     INIT_INTERP,
     "fp",
     { fp: LANGUAGES.fp },

--- a/apps/languageWorkbench/main.tsx
+++ b/apps/languageWorkbench/main.tsx
@@ -7,12 +7,10 @@ import { EditorState } from "../../uiCommon/ide/types";
 import { LANGUAGES } from "../../languageWorkbench/languages";
 import useHashParam from "use-hash-param";
 import { ErrorList } from "../../uiCommon/ide/errorList";
-import { InterpCache, addCursor } from "../../languageWorkbench/interpCache";
+import { addCursor } from "../../languageWorkbench/interpCache";
 import { CollapsibleWithHeading } from "../../uiCommon/generic/collapsible";
-import { INIT_INTERP } from "../../languageWorkbench/vscode/common";
 import { LanguageSpec } from "../../languageWorkbench/common/types";
-
-const CACHE = new InterpCache();
+import { CACHE } from "../../languageWorkbench/vscode/common";
 
 function Main() {
   return <Workbench />;
@@ -35,7 +33,6 @@ function Workbench() {
 
   const uri = `test.${curLangID}`;
   const interpWithoutCursor = CACHE.getInterpForDoc(
-    INIT_INTERP,
     versionedLangID,
     {
       [versionedLangID]: curLangSpec,

--- a/apps/languageWorkbench/main.tsx
+++ b/apps/languageWorkbench/main.tsx
@@ -7,13 +7,12 @@ import { EditorState } from "../../uiCommon/ide/types";
 import { LANGUAGES } from "../../languageWorkbench/languages";
 import useHashParam from "use-hash-param";
 import { ErrorList } from "../../uiCommon/ide/errorList";
-import {
-  addCursor,
-  getInterpForDoc,
-} from "../../languageWorkbench/interpCache";
+import { InterpCache, addCursor } from "../../languageWorkbench/interpCache";
 import { CollapsibleWithHeading } from "../../uiCommon/generic/collapsible";
 import { INIT_INTERP } from "../../languageWorkbench/vscode/common";
 import { LanguageSpec } from "../../languageWorkbench/common/types";
+
+const CACHE = new InterpCache();
 
 function Main() {
   return <Workbench />;
@@ -35,7 +34,7 @@ function Workbench() {
   };
 
   const uri = `test.${curLangID}`;
-  const interpWithoutCursor = getInterpForDoc(
+  const interpWithoutCursor = CACHE.getInterpForDoc(
     INIT_INTERP,
     versionedLangID,
     {

--- a/languageWorkbench/benchmarks.ts
+++ b/languageWorkbench/benchmarks.ts
@@ -10,7 +10,7 @@ import { extractRuleTree } from "./parserlib/ruleTree";
 import { flattenByRule } from "./parserlib/flattenByRule";
 import { getSemanticTokens, ideCurrentSuggestion } from "./common/ide";
 import { datalogLangImpl } from "./languages/dl/dl";
-import { addCursor, getInterpForDoc } from "./interpCache";
+import { InterpCache, addCursor } from "./interpCache";
 import { AbstractInterpreter } from "../core/abstractInterpreter";
 import * as fs from "fs";
 import { assertDeepEqual } from "../util/testBench/testing";
@@ -229,7 +229,9 @@ const langSpec: LanguageSpec = {
   example: "",
 };
 
-let interp: AbstractInterpreter = getInterpForDoc(
+const CACHE = new InterpCache();
+
+let interp: AbstractInterpreter = CACHE.getInterpForDoc(
   new SimpleInterpreter("languageWorkbench/common", fsLoader),
   langSpec.name,
   { [langSpec.name]: langSpec },

--- a/languageWorkbench/ddTests.ts
+++ b/languageWorkbench/ddTests.ts
@@ -8,7 +8,6 @@ import * as fs from "fs";
 import { Suite } from "../util/testBench/testing";
 import { LanguageSpec } from "./common/types";
 import { IncrementalInterpreter } from "../core/incremental/interpreter";
-import { AbstractInterpreter } from "../core/abstractInterpreter";
 
 const BASE_PATH = "languageWorkbench/common";
 

--- a/languageWorkbench/ddTests.ts
+++ b/languageWorkbench/ddTests.ts
@@ -1,6 +1,6 @@
 import { fsLoader } from "../core/fsLoader";
 import { SimpleInterpreter } from "../core/simple/interpreter";
-import { addCursor, clearInterpCache, getInterpForDoc } from "./interpCache";
+import { InterpCache, addCursor } from "./interpCache";
 import { TestOutput } from "../util/ddTest";
 import { runDDTestAtPathTwoVariants } from "../util/ddTest/runner";
 import { datalogOut } from "../util/ddTest/types";
@@ -11,6 +11,8 @@ import { IncrementalInterpreter } from "../core/incremental/interpreter";
 import { AbstractInterpreter } from "../core/abstractInterpreter";
 
 const BASE_PATH = "languageWorkbench/common";
+
+const CACHE = new InterpCache();
 
 export function lwbTests(writeResults: boolean): Suite {
   return [
@@ -42,7 +44,7 @@ export function lwbTests(writeResults: boolean): Suite {
         },
         writeResults
       );
-      clearInterpCache();
+      CACHE.clear();
     },
   }));
 }
@@ -69,7 +71,7 @@ export function testLangQuery(
       ),
       example: "",
     };
-    const { interp: withoutCursor } = getInterpForDoc(
+    const { interp: withoutCursor } = CACHE.getInterpForDoc(
       initInterp,
       langName,
       { [langName]: langSpec },
@@ -79,7 +81,7 @@ export function testLangQuery(
     const finalInterp = addCursor(withoutCursor, cursorPos);
     try {
       const results = finalInterp.queryStr(query);
-      clearInterpCache();
+      CACHE.clear();
       return datalogOut(results.map((res) => res.term));
     } catch (e) {
       console.log(e);

--- a/languageWorkbench/interpCache.ts
+++ b/languageWorkbench/interpCache.ts
@@ -14,6 +14,7 @@ type ConstructInterpRes = {
   errors: string[];
 };
 
+// TODO: generalize to Salsa-like runtime?
 export class InterpCache {
   interpCache: {
     [languageID: string]: { interp: AbstractInterpreter; grammar: Grammar };

--- a/languageWorkbench/interpCache.ts
+++ b/languageWorkbench/interpCache.ts
@@ -29,6 +29,31 @@ export class InterpCache {
     this.interpSourceCache = {};
   }
 
+  getInterpForDoc(
+    initInterp: AbstractInterpreter,
+    langID: string,
+    languages: { [langID: string]: LanguageSpec },
+    uri: string,
+    source: string
+  ): { interp: AbstractInterpreter } {
+    this.updateDocSource(uri, langID, source);
+    const key = `${langID}-${uri}`;
+    let res = this.interpSourceCache[key];
+    // TODO: this is a big memory leak
+    if (!res) {
+      res = this.addSourceInner(
+        initInterp,
+        langID,
+        languages,
+        this.docSource[uri]
+      );
+      this.interpSourceCache[key] = res;
+    } else {
+      // console.log("cache hit", langID, uri, "source length", source.length);
+    }
+    return res;
+  }
+
   // TODO: remove this hack
   clear() {
     for (const key in this.interpCache) {
@@ -49,7 +74,7 @@ export class InterpCache {
     }
   }
 
-  interpForLangSpec(
+  private interpForLangSpec(
     initInterp: AbstractInterpreter,
     languages: { [langID: string]: LanguageSpec }, // TODO: check this as well
     langID: string
@@ -104,31 +129,6 @@ export class InterpCache {
       grammar,
       errors: [...allGrammarErrors, ...dlErrors],
     };
-  }
-
-  getInterpForDoc(
-    initInterp: AbstractInterpreter,
-    langID: string,
-    languages: { [langID: string]: LanguageSpec },
-    uri: string,
-    source: string
-  ): { interp: AbstractInterpreter } {
-    this.updateDocSource(uri, langID, source);
-    const key = `${langID}-${uri}`;
-    let res = this.interpSourceCache[key];
-    // TODO: this is a big memory leak
-    if (!res) {
-      res = this.addSourceInner(
-        initInterp,
-        langID,
-        languages,
-        this.docSource[uri]
-      );
-      this.interpSourceCache[key] = res;
-    } else {
-      // console.log("cache hit", langID, uri, "source length", source.length);
-    }
-    return res;
   }
 
   private addSourceInner(

--- a/languageWorkbench/interpCache.ts
+++ b/languageWorkbench/interpCache.ts
@@ -66,7 +66,7 @@ export class InterpCache {
 
   // TODO: separate function to inject the langSource
   // so we can memoize that separately
-  interpForLangSpecInner(
+  private interpForLangSpecInner(
     initInterp: AbstractInterpreter,
     langSpec: LanguageSpec
   ): ConstructInterpRes {
@@ -131,7 +131,7 @@ export class InterpCache {
     return res;
   }
 
-  addSourceInner(
+  private addSourceInner(
     initInterp: AbstractInterpreter,
     langID: string,
     languages: { [langID: string]: LanguageSpec },

--- a/languageWorkbench/interpCache.ts
+++ b/languageWorkbench/interpCache.ts
@@ -14,146 +14,162 @@ type ConstructInterpRes = {
   errors: string[];
 };
 
-const interpCache: {
-  [languageID: string]: { interp: AbstractInterpreter; grammar: Grammar };
-} = {};
-const docSource: { [uri: string]: string } = {};
-const interpSourceCache: {
-  [docURI: string]: { interp: AbstractInterpreter };
-} = {};
+export class InterpCache {
+  interpCache: {
+    [languageID: string]: { interp: AbstractInterpreter; grammar: Grammar };
+  };
+  docSource: { [uri: string]: string };
+  interpSourceCache: {
+    [docURI: string]: { interp: AbstractInterpreter };
+  };
 
-// TODO: remove this hack
-export function clearInterpCache() {
-  for (const key in interpCache) {
-    delete interpCache[key];
+  constructor() {
+    this.interpCache = {};
+    this.docSource = {};
+    this.interpSourceCache = {};
   }
-  for (const key in interpSourceCache) {
-    delete interpSourceCache[key];
-  }
-}
 
-// TODO: call this from the outside on vscode document change events
-export function updateDocSource(uri: string, langID: string, source: string) {
-  const currentSource = docSource[uri];
-  if (currentSource !== source) {
-    docSource[uri] = source;
-    // TODO: factor invalidation out into a framework
-    delete interpSourceCache[`${langID}-${uri}`];
-  }
-}
-
-function interpForLangSpec(
-  initInterp: AbstractInterpreter,
-  languages: { [langID: string]: LanguageSpec }, // TODO: check this as well
-  langID: string
-): { interp: AbstractInterpreter; grammar: Grammar } {
-  let res = interpCache[langID];
-  if (!res) {
-    res = interpForLangSpecInner(initInterp, languages[langID]);
-    interpCache[langID] = res;
-  } else {
-    // console.log("cache hit", langID);
-  }
-  return res;
-}
-
-// TODO: separate function to inject the langSource
-// so we can memoize that separately
-function interpForLangSpecInner(
-  initInterp: AbstractInterpreter,
-  langSpec: LanguageSpec
-): ConstructInterpRes {
-  // console.log("interpForLangSpecInner", langSpec.name);
-
-  let interp = initInterp;
-  interp = interp.doLoad("main.dl");
-
-  let dlErrors: string[] = [];
-
-  // process grammar
-  const grammarTree = parseMain(langSpec.grammar);
-  const grammar = parserGrammarToInternal(grammarTree);
-  const noMainError = grammar.main ? [] : ["grammar has no 'main' rule"];
-  // TODO: get grammar parse errors
-  const allGrammarErrors = [...noMainError];
-
-  // add datalog
-  try {
-    if (langSpec.datalog.length > 0) {
-      interp = interp.evalStr(langSpec.datalog)[1];
+  // TODO: remove this hack
+  clear() {
+    for (const key in this.interpCache) {
+      delete this.interpCache[key];
     }
-    interp = interp.evalRawStmts(declareTables(grammar))[1];
-    interp = interp.evalStmt({
-      type: "Rule",
-      rule: getUnionRule(grammar),
-    })[1];
-    interp = ensureRequiredRelations(interp);
-  } catch (e) {
-    dlErrors = [e.toString()];
+    for (const key in this.interpSourceCache) {
+      delete this.interpSourceCache[key];
+    }
   }
 
-  return {
-    interp,
-    grammar,
-    errors: [...allGrammarErrors, ...dlErrors],
-  };
-}
-
-export function getInterpForDoc(
-  initInterp: AbstractInterpreter,
-  langID: string,
-  languages: { [langID: string]: LanguageSpec },
-  uri: string,
-  source: string
-): { interp: AbstractInterpreter } {
-  updateDocSource(uri, langID, source);
-  const key = `${langID}-${uri}`;
-  let res = interpSourceCache[key];
-  // TODO: this is a big memory leak
-  if (!res) {
-    res = addSourceInner(initInterp, langID, languages, docSource[uri]);
-    interpSourceCache[key] = res;
-  } else {
-    // console.log("cache hit", langID, uri, "source length", source.length);
-  }
-  return res;
-}
-
-function addSourceInner(
-  initInterp: AbstractInterpreter,
-  langID: string,
-  languages: { [langID: string]: LanguageSpec },
-  source: string
-): ConstructInterpRes {
-  let { interp, grammar } = interpForLangSpec(initInterp, languages, langID);
-
-  // initialize stuff that we'll fill in later, if parse succeeds
-  let traceTree: TraceTree = null;
-  let ruleTree: RuleTree = null;
-  let langParseError: string | null = null;
-
-  try {
-    traceTree = parse(grammar, "main", source);
-    ruleTree = extractRuleTree(traceTree);
-    const records = flatten(ruleTree, source);
-    interp = interp.bulkInsert(records);
-  } catch (e) {
-    langParseError = e.toString();
-    console.error(e);
+  // TODO: call this from the outside on vscode document change events
+  updateDocSource(uri: string, langID: string, source: string) {
+    const currentSource = this.docSource[uri];
+    if (currentSource !== source) {
+      this.docSource[uri] = source;
+      // TODO: factor invalidation out into a framework
+      delete this.interpSourceCache[`${langID}-${uri}`];
+    }
   }
 
-  // (interp as SimpleInterpreter).db.tables.mapEntries(([name, collection]) => {
-  //   console.log(name, collection.all().toArray());
-  //   return [name, collection];
-  // });
+  interpForLangSpec(
+    initInterp: AbstractInterpreter,
+    languages: { [langID: string]: LanguageSpec }, // TODO: check this as well
+    langID: string
+  ): { interp: AbstractInterpreter; grammar: Grammar } {
+    let res = this.interpCache[langID];
+    if (!res) {
+      res = this.interpForLangSpecInner(initInterp, languages[langID]);
+      this.interpCache[langID] = res;
+    } else {
+      // console.log("cache hit", langID);
+    }
+    return res;
+  }
 
-  return {
-    interp,
-    grammar,
-    errors: langParseError ? [langParseError] : [],
-  };
+  // TODO: separate function to inject the langSource
+  // so we can memoize that separately
+  interpForLangSpecInner(
+    initInterp: AbstractInterpreter,
+    langSpec: LanguageSpec
+  ): ConstructInterpRes {
+    // console.log("interpForLangSpecInner", langSpec.name);
+
+    let interp = initInterp;
+    interp = interp.doLoad("main.dl");
+
+    let dlErrors: string[] = [];
+
+    // process grammar
+    const grammarTree = parseMain(langSpec.grammar);
+    const grammar = parserGrammarToInternal(grammarTree);
+    const noMainError = grammar.main ? [] : ["grammar has no 'main' rule"];
+    // TODO: get grammar parse errors
+    const allGrammarErrors = [...noMainError];
+
+    // add datalog
+    try {
+      if (langSpec.datalog.length > 0) {
+        interp = interp.evalStr(langSpec.datalog)[1];
+      }
+      interp = interp.evalRawStmts(declareTables(grammar))[1];
+      interp = interp.evalStmt({
+        type: "Rule",
+        rule: getUnionRule(grammar),
+      })[1];
+      interp = ensureRequiredRelations(interp);
+    } catch (e) {
+      dlErrors = [e.toString()];
+    }
+
+    return {
+      interp,
+      grammar,
+      errors: [...allGrammarErrors, ...dlErrors],
+    };
+  }
+
+  getInterpForDoc(
+    initInterp: AbstractInterpreter,
+    langID: string,
+    languages: { [langID: string]: LanguageSpec },
+    uri: string,
+    source: string
+  ): { interp: AbstractInterpreter } {
+    this.updateDocSource(uri, langID, source);
+    const key = `${langID}-${uri}`;
+    let res = this.interpSourceCache[key];
+    // TODO: this is a big memory leak
+    if (!res) {
+      res = this.addSourceInner(
+        initInterp,
+        langID,
+        languages,
+        this.docSource[uri]
+      );
+      this.interpSourceCache[key] = res;
+    } else {
+      // console.log("cache hit", langID, uri, "source length", source.length);
+    }
+    return res;
+  }
+
+  addSourceInner(
+    initInterp: AbstractInterpreter,
+    langID: string,
+    languages: { [langID: string]: LanguageSpec },
+    source: string
+  ): ConstructInterpRes {
+    let { interp, grammar } = this.interpForLangSpec(
+      initInterp,
+      languages,
+      langID
+    );
+
+    // initialize stuff that we'll fill in later, if parse succeeds
+    let traceTree: TraceTree = null;
+    let ruleTree: RuleTree = null;
+    let langParseError: string | null = null;
+
+    try {
+      traceTree = parse(grammar, "main", source);
+      ruleTree = extractRuleTree(traceTree);
+      const records = flatten(ruleTree, source);
+      interp = interp.bulkInsert(records);
+    } catch (e) {
+      langParseError = e.toString();
+      console.error(e);
+    }
+
+    // (interp as SimpleInterpreter).db.tables.mapEntries(([name, collection]) => {
+    //   console.log(name, collection.all().toArray());
+    //   return [name, collection];
+    // });
+
+    return {
+      interp,
+      grammar,
+      errors: langParseError ? [langParseError] : [],
+    };
+  }
 }
-
 export function addCursor(
   interp: AbstractInterpreter,
   cursorPos: number

--- a/languageWorkbench/interpCache.ts
+++ b/languageWorkbench/interpCache.ts
@@ -16,6 +16,7 @@ type ConstructInterpRes = {
 
 // TODO: generalize to Salsa-like runtime?
 export class InterpCache {
+  getInitInterp: () => AbstractInterpreter;
   interpCache: {
     [languageID: string]: { interp: AbstractInterpreter; grammar: Grammar };
   };
@@ -24,14 +25,14 @@ export class InterpCache {
     [docURI: string]: { interp: AbstractInterpreter };
   };
 
-  constructor() {
+  constructor(getInitInterp: () => AbstractInterpreter) {
+    this.getInitInterp = getInitInterp;
     this.interpCache = {};
     this.docSource = {};
     this.interpSourceCache = {};
   }
 
   getInterpForDoc(
-    initInterp: AbstractInterpreter,
     langID: string,
     languages: { [langID: string]: LanguageSpec },
     uri: string,
@@ -40,6 +41,7 @@ export class InterpCache {
     this.updateDocSource(uri, langID, source);
     const key = `${langID}-${uri}`;
     let res = this.interpSourceCache[key];
+    const initInterp = this.getInitInterp();
     // TODO: this is a big memory leak
     if (!res) {
       res = this.addSourceInner(

--- a/languageWorkbench/vscode/common.ts
+++ b/languageWorkbench/vscode/common.ts
@@ -5,7 +5,7 @@ import { LOADER } from "../common";
 import { LanguageSpec } from "../common/types";
 import { InterpCache } from "../interpCache";
 
-const CACHE = new InterpCache();
+export const CACHE = new InterpCache();
 
 // needs to match https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#semantic-token-classification
 // and highlight.dl

--- a/languageWorkbench/vscode/common.ts
+++ b/languageWorkbench/vscode/common.ts
@@ -5,7 +5,7 @@ import { LOADER } from "../common";
 import { LanguageSpec } from "../common/types";
 import { InterpCache } from "../interpCache";
 
-export const CACHE = new InterpCache();
+export const CACHE = new InterpCache(() => new SimpleInterpreter(".", LOADER));
 
 // needs to match https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#semantic-token-classification
 // and highlight.dl
@@ -18,8 +18,6 @@ export const TOKEN_TYPES = [
   "typeParameter",
 ];
 
-export const INIT_INTERP = new SimpleInterpreter(".", LOADER);
-
 export function getInterp(
   language: LanguageSpec,
   uri: string,
@@ -27,7 +25,6 @@ export function getInterp(
 ): AbstractInterpreter {
   console.log("getInterp", language.name);
   const res = CACHE.getInterpForDoc(
-    INIT_INTERP,
     language.name,
     { [language.name]: language },
     uri,

--- a/languageWorkbench/vscode/common.ts
+++ b/languageWorkbench/vscode/common.ts
@@ -3,7 +3,9 @@ import { SimpleInterpreter } from "../../core/simple/interpreter";
 import { rec } from "../../core/types";
 import { LOADER } from "../common";
 import { LanguageSpec } from "../common/types";
-import { getInterpForDoc } from "../interpCache";
+import { InterpCache } from "../interpCache";
+
+const CACHE = new InterpCache();
 
 // needs to match https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#semantic-token-classification
 // and highlight.dl
@@ -24,7 +26,7 @@ export function getInterp(
   source: string
 ): AbstractInterpreter {
   console.log("getInterp", language.name);
-  const res = getInterpForDoc(
+  const res = CACHE.getInterpForDoc(
     INIT_INTERP,
     language.name,
     { [language.name]: language },

--- a/languageWorkbench/vscode/vscodeIntegration.ts
+++ b/languageWorkbench/vscode/vscodeIntegration.ts
@@ -6,7 +6,7 @@ import {
   lineAndColFromIdx,
 } from "../sourcePositions";
 import { ppt } from "../../core/pretty";
-import { getInterp, GLOBAL_SCOPE, TOKEN_TYPES } from "./common";
+import { CACHE, getInterp, GLOBAL_SCOPE, TOKEN_TYPES } from "./common";
 import { uniqBy } from "../../util/util";
 import * as native from "../common/ide";
 import {
@@ -18,7 +18,6 @@ import { extractRuleTree } from "../parserlib/ruleTree";
 import { parse } from "../parserlib/parser";
 import { Span } from "../parserlib/types";
 import { LangImpl, LanguageSpec, Problem } from "../common/types";
-import { updateDocSource } from "../interpCache";
 
 export function registerLanguageSupport(
   spec: LanguageSpec
@@ -484,8 +483,7 @@ function getFlattened(
   source: string,
   leaves: Set<string> = new Set<string>()
 ): NodesByRule {
-  // call updateSource here?
-  updateDocSource(uri, langID, source);
+  CACHE.updateDocSource(uri, langID, source);
   const traceTree = parse(impl.grammar, "main", source);
   const ruleTree = extractRuleTree(traceTree);
   return flattenByRule(ruleTree, source, leaves);

--- a/uiCommon/ide/editor.tsx
+++ b/uiCommon/ide/editor.tsx
@@ -9,11 +9,9 @@ import {
 import { EditorState } from "./types";
 import { addKeyBinding, removeKeyBinding } from "./patchKeyBindings";
 import { KeyBindingsTable } from "./keymap/keyBindingsTable";
-import { InterpCache, addCursor } from "../../languageWorkbench/interpCache";
-import { INIT_INTERP } from "../../languageWorkbench/vscode/common";
+import { addCursor } from "../../languageWorkbench/interpCache";
 import { LanguageSpec } from "../../languageWorkbench/common/types";
-
-const CACHE = new InterpCache();
+import { CACHE } from "../../languageWorkbench/vscode/common";
 
 export function LingoEditor(props: {
   editorState: EditorState;
@@ -95,7 +93,6 @@ export function LingoEditor(props: {
   // instances... sigh
   const withoutCursor = useMemo(() => {
     const res = CACHE.getInterpForDoc(
-      INIT_INTERP,
       props.langSpec.name,
       { [props.langSpec.name]: props.langSpec },
       `test.${props.langSpec.name}`,

--- a/uiCommon/ide/editor.tsx
+++ b/uiCommon/ide/editor.tsx
@@ -9,12 +9,11 @@ import {
 import { EditorState } from "./types";
 import { addKeyBinding, removeKeyBinding } from "./patchKeyBindings";
 import { KeyBindingsTable } from "./keymap/keyBindingsTable";
-import {
-  addCursor,
-  getInterpForDoc,
-} from "../../languageWorkbench/interpCache";
+import { InterpCache, addCursor } from "../../languageWorkbench/interpCache";
 import { INIT_INTERP } from "../../languageWorkbench/vscode/common";
 import { LanguageSpec } from "../../languageWorkbench/common/types";
+
+const CACHE = new InterpCache();
 
 export function LingoEditor(props: {
   editorState: EditorState;
@@ -95,7 +94,7 @@ export function LingoEditor(props: {
   // constructInterp has its own memoization, but that doesn't work across multiple LingoEditor
   // instances... sigh
   const withoutCursor = useMemo(() => {
-    const res = getInterpForDoc(
+    const res = CACHE.getInterpForDoc(
       INIT_INTERP,
       props.langSpec.name,
       { [props.langSpec.name]: props.langSpec },


### PR DESCRIPTION
Gets rid of some global vars.

The structure of this makes more sense for the simple interpreter, which is immutable, than it does for the incremental interpreter, which is mutable…