### PR TITLE
incremental recursion maintenance: add test of multiple supports

### DIFF
--- a/core/incremental/ddTests.ts
+++ b/core/incremental/ddTests.ts
@@ -32,6 +32,7 @@ export function incrTests(writeResults: boolean): Suite {
     ["timeStep", evalTest],
     ["contracts", evalTest],
     ["transitiveClosure", evalTest],
+    ["transitiveClosureMultiSupport", evalTest],
     ["sccs", evalTest],
     ["parse", evalTest],
     ["aggregation", evalTest],

--- a/core/incremental/testdata/transitiveClosureMultiSupport.dd.txt
+++ b/core/incremental/testdata/transitiveClosureMultiSupport.dd.txt
@@ -26,103 +26,105 @@ reach: [reach{from: "a", to: "b"}+1]
 3: [{B: "a", C: "b"}+1]
 4: []
 
-edge{from: "b", to: "a"}.
+edge{from: "b", to: "c"}.
 ----
 incremental-datalog/trace
-edge: [edge{from: "b", to: "a"}+1]
-1: [{A: "b", C: "a"}+1]
-2: [{A: "b", B: "a"}+1]
-0: [{A: "b", C: "a"}+1]
-4: [{A: "b", B: "a", C: "b"}+1]
-5: [{A: "b", C: "a"}+1]
-0: [{A: "b", B: "a", C: "b"}+1]
-reach: [reach{from: "b", to: "a"}+1]
-5: [{A: "b", B: "a", C: "b"}+1]
-3: [{B: "b", C: "a"}+1]
-reach: [reach{from: "b", to: "b"}+1]
-4: [{A: "a", B: "b", C: "a"}+1]
-3: [{B: "b", C: "b"}+1]
-0: [{A: "a", B: "b", C: "a"}+1]
-4: [{A: "a", B: "b", C: "b"}+1]
-5: [{A: "a", B: "b", C: "a"}+1]
-0: [{A: "a", B: "b", C: "b"}+1]
-reach: [reach{from: "a", to: "a"}+1]
-5: [{A: "a", B: "b", C: "b"}+1]
-3: [{B: "a", C: "a"}+1]
-reach: [reach{from: "a", to: "b"}+1]
-4: [{A: "b", B: "a", C: "a"}+1]
-3: [{B: "a", C: "b"}+1]
-0: [{A: "b", B: "a", C: "a"}+1]
-4: [{A: "b", B: "a", C: "b"}+1]
-5: [{A: "b", B: "a", C: "a"}+1]
-0: [{A: "b", B: "a", C: "b"}+1]
-reach: [reach{from: "b", to: "a"}+1]
-5: []
-3: [{B: "b", C: "a"}+1]
-4: [{A: "a", B: "b", C: "a"}+1]
-0: [{A: "a", B: "b", C: "a"}+1]
-5: []
+edge: [edge{from: "b", to: "c"}+1]
+1: [{A: "b", C: "c"}+1]
+2: [{A: "b", B: "c"}+1]
+0: [{A: "b", C: "c"}+1]
+4: []
+5: [{A: "b", C: "c"}+1]
+reach: [reach{from: "b", to: "c"}+1]
+3: [{B: "b", C: "c"}+1]
+4: [{A: "a", B: "b", C: "c"}+1]
+0: [{A: "a", B: "b", C: "c"}+1]
+5: [{A: "a", B: "b", C: "c"}+1]
+reach: [reach{from: "a", to: "c"}+1]
+3: [{B: "a", C: "c"}+1]
+4: []
 
-edge{from: "c", to: "a"}.
+edge{from: "c", to: "b"}.
 ----
 incremental-datalog/trace
-edge: [edge{from: "c", to: "a"}+1]
-1: [{A: "c", C: "a"}+1]
-2: [{A: "c", B: "a"}+1]
-0: [{A: "c", C: "a"}+1]
-4: [{A: "c", B: "a", C: "b"}+2, {A: "c", B: "a", C: "a"}+1]
-5: [{A: "c", C: "a"}+1]
-0: [{A: "c", B: "a", C: "b"}+2]
-0: [{A: "c", B: "a", C: "a"}+1]
-reach: [reach{from: "c", to: "a"}+1]
-5: [{A: "c", B: "a", C: "b"}+1]
-5: [{A: "c", B: "a", C: "a"}+1]
-3: [{B: "c", C: "a"}+1]
+edge: [edge{from: "c", to: "b"}+1]
+1: [{A: "c", C: "b"}+1]
+2: [{A: "c", B: "b"}+1]
+0: [{A: "c", C: "b"}+1]
+4: [{A: "c", B: "b", C: "c"}+1]
+5: [{A: "c", C: "b"}+1]
+0: [{A: "c", B: "b", C: "c"}+1]
 reach: [reach{from: "c", to: "b"}+1]
-reach: [reach{from: "c", to: "a"}+1]
-4: []
+5: [{A: "c", B: "b", C: "c"}+1]
 3: [{B: "c", C: "b"}+1]
-3: [{B: "c", C: "a"}+1]
+reach: [reach{from: "c", to: "c"}+1]
+4: [{A: "b", B: "c", C: "b"}+1]
+3: [{B: "c", C: "c"}+1]
+0: [{A: "b", B: "c", C: "b"}+1]
+4: [{A: "b", B: "c", C: "c"}+1]
+5: [{A: "b", B: "c", C: "b"}+1]
+0: [{A: "b", B: "c", C: "c"}+1]
+reach: [reach{from: "b", to: "b"}+1]
+5: [{A: "b", B: "c", C: "c"}+1]
+3: [{B: "b", C: "b"}+1]
+reach: [reach{from: "b", to: "c"}+1]
+4: [{A: "a", B: "b", C: "b"}+1, {A: "c", B: "b", C: "b"}+1]
+3: [{B: "b", C: "c"}+1]
+0: [{A: "a", B: "b", C: "b"}+1]
+0: [{A: "c", B: "b", C: "b"}+1]
+4: [{A: "a", B: "b", C: "c"}+1, {A: "c", B: "b", C: "c"}+1]
+5: [{A: "a", B: "b", C: "b"}+1]
+5: [{A: "c", B: "b", C: "b"}+1]
+0: [{A: "a", B: "b", C: "c"}+1]
+0: [{A: "c", B: "b", C: "c"}+1]
+reach: [reach{from: "a", to: "b"}+1]
+reach: [reach{from: "c", to: "b"}+1]
+5: []
+5: []
+3: [{B: "a", C: "b"}+1]
+3: [{B: "c", C: "b"}+1]
 4: []
-4: []
+4: [{A: "b", B: "c", C: "b"}+1]
+0: [{A: "b", B: "c", C: "b"}+1]
+5: []
 
 reach{}?
 ----
 application/datalog
-reach{from: "a", to: "a"}.
 reach{from: "a", to: "b"}.
-reach{from: "b", to: "a"}.
+reach{from: "a", to: "c"}.
 reach{from: "b", to: "b"}.
-reach{from: "c", to: "a"}.
+reach{from: "b", to: "c"}.
 reach{from: "c", to: "b"}.
+reach{from: "c", to: "c"}.
 
--edge{from: "c", to: "a"}.
+-edge{from: "a", to: "b"}.
 ----
 incremental-datalog/trace
-edge: [edge{from: "c", to: "a"}-1]
-1: [{A: "c", C: "a"}-1]
-2: [{A: "c", B: "a"}-1]
-0: [{A: "c", C: "a"}-1]
-4: [{A: "c", B: "a", C: "b"}-2, {A: "c", B: "a", C: "a"}-1]
-5: [{A: "c", C: "a"}-1]
-0: [{A: "c", B: "a", C: "b"}-2]
-0: [{A: "c", B: "a", C: "a"}-1]
-reach: [reach{from: "c", to: "a"}-1]
-5: [{A: "c", B: "a", C: "b"}-1]
-5: [{A: "c", B: "a", C: "a"}-1]
-3: [{B: "c", C: "a"}-1]
-reach: [reach{from: "c", to: "b"}-1]
-reach: [reach{from: "c", to: "a"}-1]
+edge: [edge{from: "a", to: "b"}-1]
+1: [{A: "a", C: "b"}-1]
+2: [{A: "a", B: "b"}-1]
+0: [{A: "a", C: "b"}-1]
+4: [{A: "a", B: "b", C: "c"}-2, {A: "a", B: "b", C: "b"}-1]
+5: [{A: "a", C: "b"}-1]
+0: [{A: "a", B: "b", C: "c"}-2]
+0: [{A: "a", B: "b", C: "b"}-1]
+reach: [reach{from: "a", to: "b"}-1]
+5: [{A: "a", B: "b", C: "c"}-1]
+5: [{A: "a", B: "b", C: "b"}-1]
+3: [{B: "a", C: "b"}-1]
+reach: [reach{from: "a", to: "c"}-1]
+reach: [reach{from: "a", to: "b"}-1]
 4: []
-3: [{B: "c", C: "b"}-1]
-3: [{B: "c", C: "a"}-1]
+3: [{B: "a", C: "c"}-1]
+3: [{B: "a", C: "b"}-1]
 4: []
 4: []
 
 reach{}?
 ----
 application/datalog
-reach{from: "a", to: "a"}.
-reach{from: "a", to: "b"}.
-reach{from: "b", to: "a"}.
 reach{from: "b", to: "b"}.
+reach{from: "b", to: "c"}.
+reach{from: "c", to: "b"}.
+reach{from: "c", to: "c"}.

--- a/core/incremental/testdata/transitiveClosureMultiSupport.dd.txt
+++ b/core/incremental/testdata/transitiveClosureMultiSupport.dd.txt
@@ -1,0 +1,128 @@
+.table edge
+----
+application/datalog
+
+reach{from: A, to: C} :-
+  edge{from: A, to: C} |
+  edge{from: A, to: B} &
+  reach{from: B, to: C}.
+----
+application/datalog
+
+reach{}?
+----
+application/datalog
+
+edge{from: "a", to: "b"}.
+----
+incremental-datalog/trace
+edge: [edge{from: "a", to: "b"}+1]
+1: [{A: "a", C: "b"}+1]
+2: [{A: "a", B: "b"}+1]
+0: [{A: "a", C: "b"}+1]
+4: []
+5: [{A: "a", C: "b"}+1]
+reach: [reach{from: "a", to: "b"}+1]
+3: [{B: "a", C: "b"}+1]
+4: []
+
+edge{from: "b", to: "a"}.
+----
+incremental-datalog/trace
+edge: [edge{from: "b", to: "a"}+1]
+1: [{A: "b", C: "a"}+1]
+2: [{A: "b", B: "a"}+1]
+0: [{A: "b", C: "a"}+1]
+4: [{A: "b", B: "a", C: "b"}+1]
+5: [{A: "b", C: "a"}+1]
+0: [{A: "b", B: "a", C: "b"}+1]
+reach: [reach{from: "b", to: "a"}+1]
+5: [{A: "b", B: "a", C: "b"}+1]
+3: [{B: "b", C: "a"}+1]
+reach: [reach{from: "b", to: "b"}+1]
+4: [{A: "a", B: "b", C: "a"}+1]
+3: [{B: "b", C: "b"}+1]
+0: [{A: "a", B: "b", C: "a"}+1]
+4: [{A: "a", B: "b", C: "b"}+1]
+5: [{A: "a", B: "b", C: "a"}+1]
+0: [{A: "a", B: "b", C: "b"}+1]
+reach: [reach{from: "a", to: "a"}+1]
+5: [{A: "a", B: "b", C: "b"}+1]
+3: [{B: "a", C: "a"}+1]
+reach: [reach{from: "a", to: "b"}+1]
+4: [{A: "b", B: "a", C: "a"}+1]
+3: [{B: "a", C: "b"}+1]
+0: [{A: "b", B: "a", C: "a"}+1]
+4: [{A: "b", B: "a", C: "b"}+1]
+5: [{A: "b", B: "a", C: "a"}+1]
+0: [{A: "b", B: "a", C: "b"}+1]
+reach: [reach{from: "b", to: "a"}+1]
+5: []
+3: [{B: "b", C: "a"}+1]
+4: [{A: "a", B: "b", C: "a"}+1]
+0: [{A: "a", B: "b", C: "a"}+1]
+5: []
+
+edge{from: "c", to: "a"}.
+----
+incremental-datalog/trace
+edge: [edge{from: "c", to: "a"}+1]
+1: [{A: "c", C: "a"}+1]
+2: [{A: "c", B: "a"}+1]
+0: [{A: "c", C: "a"}+1]
+4: [{A: "c", B: "a", C: "b"}+2, {A: "c", B: "a", C: "a"}+1]
+5: [{A: "c", C: "a"}+1]
+0: [{A: "c", B: "a", C: "b"}+2]
+0: [{A: "c", B: "a", C: "a"}+1]
+reach: [reach{from: "c", to: "a"}+1]
+5: [{A: "c", B: "a", C: "b"}+1]
+5: [{A: "c", B: "a", C: "a"}+1]
+3: [{B: "c", C: "a"}+1]
+reach: [reach{from: "c", to: "b"}+1]
+reach: [reach{from: "c", to: "a"}+1]
+4: []
+3: [{B: "c", C: "b"}+1]
+3: [{B: "c", C: "a"}+1]
+4: []
+4: []
+
+reach{}?
+----
+application/datalog
+reach{from: "a", to: "a"}.
+reach{from: "a", to: "b"}.
+reach{from: "b", to: "a"}.
+reach{from: "b", to: "b"}.
+reach{from: "c", to: "a"}.
+reach{from: "c", to: "b"}.
+
+-edge{from: "c", to: "a"}.
+----
+incremental-datalog/trace
+edge: [edge{from: "c", to: "a"}-1]
+1: [{A: "c", C: "a"}-1]
+2: [{A: "c", B: "a"}-1]
+0: [{A: "c", C: "a"}-1]
+4: [{A: "c", B: "a", C: "b"}-2, {A: "c", B: "a", C: "a"}-1]
+5: [{A: "c", C: "a"}-1]
+0: [{A: "c", B: "a", C: "b"}-2]
+0: [{A: "c", B: "a", C: "a"}-1]
+reach: [reach{from: "c", to: "a"}-1]
+5: [{A: "c", B: "a", C: "b"}-1]
+5: [{A: "c", B: "a", C: "a"}-1]
+3: [{B: "c", C: "a"}-1]
+reach: [reach{from: "c", to: "b"}-1]
+reach: [reach{from: "c", to: "a"}-1]
+4: []
+3: [{B: "c", C: "b"}-1]
+3: [{B: "c", C: "a"}-1]
+4: []
+4: []
+
+reach{}?
+----
+application/datalog
+reach{from: "a", to: "a"}.
+reach{from: "a", to: "b"}.
+reach{from: "b", to: "a"}.
+reach{from: "b", to: "b"}.


### PR DESCRIPTION
Creates this graph:

```mermaid
flowchart LR
  a --> b
  b --> c
  c --> b
```

Then removes the `a -> b` edge:

```mermaid
flowchart LR
  a
  b --> c
  c --> b
```

Asserts that `b` and `c` are still reachable from each other.