### PR TITLE
make tables 100% width

### DIFF
--- a/apps/actors/systems/kvSync/examples/common/inspector.tsx
+++ b/apps/actors/systems/kvSync/examples/common/inspector.tsx
@@ -5,13 +5,11 @@ import { TransactionList } from "./txnList";
 import { KVInspector } from "./kvInspector";
 import { LiveQueryInspector } from "./liveQueryInspector";
 
-const MAX_WIDTH = 500;
-
 export function Inspector(props: { client: Client }) {
   const [curTab, setTab] = useState("data");
 
   return (
-    <>
+    <div style={{ width: "100%" }}>
       <h4>Inspector</h4>
       <Tabs
         curTabID={curTab}
@@ -20,32 +18,20 @@ export function Inspector(props: { client: Client }) {
           {
             id: "transactions",
             name: "Transactions",
-            render: () => (
-              <div style={{ maxWidth: MAX_WIDTH, overflow: "scroll" }}>
-                <TransactionList client={props.client} />
-              </div>
-            ),
+            render: () => <TransactionList client={props.client} />,
           },
           {
             id: "data",
             name: "Data",
-            render: () => (
-              <div style={{ maxWidth: MAX_WIDTH, overflow: "scroll" }}>
-                <KVInspector client={props.client} />
-              </div>
-            ),
+            render: () => <KVInspector client={props.client} />,
           },
           {
             id: "queries",
             name: "Queries",
-            render: () => (
-              <div style={{ maxWidth: MAX_WIDTH, overflow: "scroll" }}>
-                <LiveQueryInspector client={props.client} />
-              </div>
-            ),
+            render: () => <LiveQueryInspector client={props.client} />,
           },
         ]}
       />
-    </>
+    </div>
   );
 }

--- a/apps/actors/systems/kvSync/examples/common/table.tsx
+++ b/apps/actors/systems/kvSync/examples/common/table.tsx
@@ -12,7 +12,7 @@ export function Table<T>(props: {
   getKey: (row: T) => string;
 }) {
   return (
-    <table style={{ borderCollapse: "collapse" }}>
+    <table style={{ borderCollapse: "collapse", width: "100%" }}>
       <thead>
         <tr style={{ borderBottom: "1px solid gray" }}>
           {props.columns.map((colSpec, colIdx) => (


### PR DESCRIPTION
avoids layout shift
<img width="1840" alt="image" src="https://github.com/vilterp/datalog-ts/assets/7341/49da5b21-42dc-43c1-be23-8bf2141ac231">
