### PR TITLE
don't show aborted transactions

### DIFF
--- a/apps/actors/systems/kvSync/client.ts
+++ b/apps/actors/systems/kvSync/client.ts
@@ -209,7 +209,10 @@ function runMutationOnClient(
 
 export function isTxnVisible(client: ClientState, txnID: string): boolean {
   const txn = client.transactions[txnID];
-  return txn.fromMe || txn.state.type === "Committed";
+  return (
+    (txn.fromMe && txn.state.type === "Pending") ||
+    txn.state.type === "Committed"
+  );
 }
 
 function addTransaction(


### PR DESCRIPTION
Only show txns from me that are pending.

Maybe this should be optional? Maybe we can let aborted ones hang around, but only for inserts, not updates?